### PR TITLE
fix: 店舗管理者ログイン・登録ページのルート修正とバリデーション改善

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
 export default function Home() {
-  redirect('/auth')
+  redirect('/shop-admin/signup')
 }

--- a/app/shop-admin/login/page.tsx
+++ b/app/shop-admin/login/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { LoginForm } from '@/features/auth/components/LoginForm'
+
+export default function LoginPage() {
+  const router = useRouter()
+
+  const handleSuccess = () => {
+    // ログイン成功後は店舗設定画面へリダイレクト
+    // TODO: 実装後に適切なパスに変更
+    router.push('/dashboard')
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white shadow-md rounded-lg p-8">
+          <div className="mb-8 text-center">
+            <h1 className="text-2xl font-bold text-gray-900">
+              ログイン
+            </h1>
+            <p className="mt-2 text-sm text-gray-600">
+              店舗管理者向け予約システム
+            </p>
+          </div>
+
+          <LoginForm onSuccess={handleSuccess} />
+        </div>
+
+        <p className="mt-8 text-center text-xs text-gray-500">
+          © 2025 店舗予約システム. All rights reserved.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/shop-admin/signup/page.tsx
+++ b/app/shop-admin/signup/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { SignUpForm } from '@/features/auth/components/SignUpForm'
+
+export default function SignUpPage() {
+  const router = useRouter()
+
+  const handleSuccess = () => {
+    // ログイン/登録成功後は店舗設定画面へリダイレクト
+    // TODO: 実装後に適切なパスに変更
+    router.push('/dashboard')
+  }
+
+  const handleSwitchToLogin = () => {
+    router.push('/shop-admin/login')
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white shadow-md rounded-lg p-8">
+          <div className="mb-8 text-center">
+            <h1 className="text-2xl font-bold text-gray-900">
+              アカウント登録
+            </h1>
+            <p className="mt-2 text-sm text-gray-600">
+              店舗管理者向け予約システム
+            </p>
+          </div>
+
+          <SignUpForm
+            onSuccess={handleSuccess}
+            onSwitchToLogin={handleSwitchToLogin}
+          />
+        </div>
+
+        <p className="mt-8 text-center text-xs text-gray-500">
+          © 2025 店舗予約システム. All rights reserved.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/features/auth/utils/validation.ts
+++ b/features/auth/utils/validation.ts
@@ -3,12 +3,15 @@ import { z } from 'zod'
 export const signUpSchema = z.object({
   userName: z
     .string()
+    .trim()
     .min(3, 'ユーザー名は3文字以上で入力してください')
     .max(50, 'ユーザー名は50文字以内で入力してください')
     .regex(/^[a-zA-Z0-9_]+$/, 'ユーザー名は半角英数字とアンダースコアのみ使用できます'),
   email: z
     .string()
-    .email('正しいメールアドレス形式で入力してください'),
+    .trim()
+    .min(1, 'Email address is required')
+    .email('Email address is invalid'),
   password: z
     .string()
     .min(8, 'パスワードは8文字以上で入力してください')


### PR DESCRIPTION
- /shop-admin/signup, /shop-admin/login ページを追加
- ルートページのリダイレクト先を /shop-admin/signup に変更
- メールアドレスバリデーションメッセージを英語化（セキュリティ観点）
- 入力値のトリミング処理を追加（userName, email）

🤖 Generated with [Claude Code](https://claude.com/claude-code)