### PR TITLE
feat: ユーザー向けマイページの実装 (Issue #15)

### DIFF
--- a/__tests__/app/user/mypage/page.test.tsx
+++ b/__tests__/app/user/mypage/page.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { useRouter } from 'next/navigation'
+import MyPage from '@/app/user/mypage/page'
+import { createClient } from '@/lib/supabase/client'
+
+// モック
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(),
+}))
+
+jest.mock('@/components/user/Header', () => ({
+  Header: ({ userName }: { userName: string }) => (
+    <div data-testid="header">Header: {userName}</div>
+  ),
+}))
+
+jest.mock('@/components/user/Footer', () => ({
+  Footer: () => <div data-testid="footer">Footer</div>,
+}))
+
+jest.mock('@/components/user/Sidebar', () => ({
+  Sidebar: () => <div data-testid="sidebar">Sidebar</div>,
+}))
+
+jest.mock('@/features/shop-search/components/SearchForm', () => ({
+  SearchForm: () => <div data-testid="search-form">SearchForm</div>,
+}))
+
+jest.mock('@/features/shop-search/components/SearchResults', () => ({
+  SearchResults: () => <div data-testid="search-results">SearchResults</div>,
+}))
+
+describe('User MyPage', () => {
+  const mockPush = jest.fn()
+  const mockSupabase = {
+    auth: {
+      getUser: jest.fn(),
+    },
+    from: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+    })
+    ;(createClient as jest.Mock).mockReturnValue(mockSupabase)
+  })
+
+  it('認証されていない場合はログインページへリダイレクトする', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error('Not authenticated'),
+    })
+
+    render(<MyPage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/login')
+    })
+  })
+
+  it('認証されている場合はマイページが表示される', async () => {
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_name: 'テストユーザー' },
+            error: null,
+          }),
+        }),
+      }),
+    })
+
+    render(<MyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('header')).toHaveTextContent('テストユーザー')
+    })
+
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument()
+    expect(screen.getByTestId('search-form')).toBeInTheDocument()
+    expect(screen.getByTestId('footer')).toBeInTheDocument()
+  })
+
+  it('ユーザー情報の取得に失敗した場合はログインページへリダイレクトする', async () => {
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: null,
+            error: new Error('User not found'),
+          }),
+        }),
+      }),
+    })
+
+    render(<MyPage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/login')
+    })
+  })
+})

--- a/__tests__/components/user/Footer.test.tsx
+++ b/__tests__/components/user/Footer.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { Footer } from '@/components/user/Footer'
+
+describe('User Footer Component', () => {
+  it('フッターテキストが表示される', () => {
+    render(<Footer />)
+
+    expect(screen.getByText('店舗予約システム')).toBeInTheDocument()
+    expect(screen.getByText(/© 2025 店舗予約システム. All rights reserved./)).toBeInTheDocument()
+  })
+
+  it('ユーザー向けマイページという文言が表示される', () => {
+    render(<Footer />)
+
+    expect(screen.getByText('ユーザー向けマイページ')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/user/Header.test.tsx
+++ b/__tests__/components/user/Header.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useRouter } from 'next/navigation'
+import { Header } from '@/components/user/Header'
+import { signOut } from '@/features/auth/utils/signOut'
+
+// モック
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+jest.mock('@/features/auth/utils/signOut', () => ({
+  signOut: jest.fn(),
+}))
+
+describe('User Header Component', () => {
+  const mockPush = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+    })
+  })
+
+  it('ユーザー名が表示される', () => {
+    render(<Header userName="テストユーザー" />)
+
+    expect(screen.getByText('テストユーザー')).toBeInTheDocument()
+  })
+
+  it('ログアウトボタンが表示される', () => {
+    render(<Header userName="テストユーザー" />)
+
+    expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument()
+  })
+
+  it('ログアウトボタンをクリックするとログアウト処理が実行される', async () => {
+    ;(signOut as jest.Mock).mockResolvedValue({ success: true })
+
+    render(<Header userName="テストユーザー" />)
+
+    const logoutButton = screen.getByRole('button', { name: 'ログアウト' })
+    fireEvent.click(logoutButton)
+
+    expect(signOut).toHaveBeenCalledTimes(1)
+  })
+
+  it('ログアウト成功時にユーザー登録画面へ遷移する', async () => {
+    ;(signOut as jest.Mock).mockResolvedValue({ success: true })
+
+    render(<Header userName="テストユーザー" />)
+
+    const logoutButton = screen.getByRole('button', { name: 'ログアウト' })
+    fireEvent.click(logoutButton)
+
+    // 非同期処理を待つ
+    await screen.findByRole('button', { name: 'ログアウト' })
+
+    expect(mockPush).toHaveBeenCalledWith('/user/signup')
+  })
+})

--- a/__tests__/components/user/Sidebar.test.tsx
+++ b/__tests__/components/user/Sidebar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Sidebar } from '@/components/user/Sidebar'
+
+describe('User Sidebar Component', () => {
+  it('サイドバーが初期状態で閉じている', () => {
+    render(<Sidebar />)
+
+    const sidebar = screen.getByRole('complementary')
+    expect(sidebar).toHaveClass('w-16')
+  })
+
+  it('トグルボタンをクリックするとサイドバーが開く', () => {
+    render(<Sidebar />)
+
+    const toggleButton = screen.getByRole('button', { name: /メニューを開く|メニューを閉じる/ })
+    fireEvent.click(toggleButton)
+
+    const sidebar = screen.getByRole('complementary')
+    expect(sidebar).toHaveClass('w-64')
+  })
+
+  it('トグルボタンを2回クリックするとサイドバーが閉じる', () => {
+    render(<Sidebar />)
+
+    const toggleButton = screen.getByRole('button', { name: /メニューを開く|メニューを閉じる/ })
+
+    // 1回目: 開く
+    fireEvent.click(toggleButton)
+    let sidebar = screen.getByRole('complementary')
+    expect(sidebar).toHaveClass('w-64')
+
+    // 2回目: 閉じる
+    fireEvent.click(toggleButton)
+    sidebar = screen.getByRole('complementary')
+    expect(sidebar).toHaveClass('w-16')
+  })
+
+  it('サイドバーが開いている時に予約履歴リンクが表示される', () => {
+    render(<Sidebar />)
+
+    const toggleButton = screen.getByRole('button', { name: /メニューを開く|メニューを閉じる/ })
+    fireEvent.click(toggleButton)
+
+    expect(screen.getByText('予約履歴')).toBeInTheDocument()
+  })
+
+  it('サイドバーが開いている時にユーザー設定ボタンが表示される', () => {
+    render(<Sidebar />)
+
+    const toggleButton = screen.getByRole('button', { name: /メニューを開く|メニューを閉じる/ })
+    fireEvent.click(toggleButton)
+
+    expect(screen.getByRole('button', { name: 'ユーザー設定' })).toBeInTheDocument()
+  })
+
+  it('サイドバーが閉じている時はテキストが表示されない', () => {
+    render(<Sidebar />)
+
+    expect(screen.queryByText('予約履歴')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'ユーザー設定' })).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/features/shop-search/components/SearchForm.test.tsx
+++ b/__tests__/features/shop-search/components/SearchForm.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SearchForm } from '@/features/shop-search/components/SearchForm'
+import { searchShops } from '@/features/shop-search/utils/searchShops'
+
+// モック
+jest.mock('@/features/shop-search/utils/searchShops', () => ({
+  searchShops: jest.fn(),
+}))
+
+describe('SearchForm Component', () => {
+  const mockOnSearch = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('検索フォームが表示される', () => {
+    render(<SearchForm onSearch={mockOnSearch} />)
+
+    expect(screen.getByLabelText('店舗名')).toBeInTheDocument()
+    expect(screen.getByLabelText('日付')).toBeInTheDocument()
+    expect(screen.getByLabelText('時間')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '検索' })).toBeInTheDocument()
+  })
+
+  it('店舗名を入力できる', () => {
+    render(<SearchForm onSearch={mockOnSearch} />)
+
+    const shopNameInput = screen.getByLabelText('店舗名') as HTMLInputElement
+    fireEvent.change(shopNameInput, { target: { value: 'テスト店舗' } })
+
+    expect(shopNameInput.value).toBe('テスト店舗')
+  })
+
+  it('日付を入力できる', () => {
+    render(<SearchForm onSearch={mockOnSearch} />)
+
+    const dateInput = screen.getByLabelText('日付') as HTMLInputElement
+    fireEvent.change(dateInput, { target: { value: '2025-12-20' } })
+
+    expect(dateInput.value).toBe('2025-12-20')
+  })
+
+  it('時間を選択できる', () => {
+    render(<SearchForm onSearch={mockOnSearch} />)
+
+    const timeSelect = screen.getByLabelText('時間') as HTMLSelectElement
+    fireEvent.change(timeSelect, { target: { value: '10:00' } })
+
+    expect(timeSelect.value).toBe('10:00')
+  })
+
+  it('検索ボタンをクリックすると検索が実行される', async () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    ;(searchShops as jest.Mock).mockResolvedValue({
+      success: true,
+      data: mockResults,
+      total: 1,
+      totalPages: 1,
+    })
+
+    render(<SearchForm onSearch={mockOnSearch} />)
+
+    const searchButton = screen.getByRole('button', { name: '検索' })
+    fireEvent.click(searchButton)
+
+    await waitFor(() => {
+      expect(searchShops).toHaveBeenCalled()
+      expect(mockOnSearch).toHaveBeenCalledWith(
+        mockResults,
+        1,
+        1,
+        expect.objectContaining({
+          shopName: undefined,
+          date: undefined,
+          time: undefined,
+        })
+      )
+    })
+  })
+
+  it('店舗名が文字数上限を超えた場合はエラーが表示される', async () => {
+    render(<SearchForm onSearch={mockOnSearch} />)
+
+    const shopNameInput = screen.getByLabelText('店舗名')
+    const longName = 'あ'.repeat(101) // 100文字を超える
+
+    fireEvent.change(shopNameInput, { target: { value: longName } })
+    fireEvent.click(screen.getByRole('button', { name: '検索' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/店舗名は100文字以下で入力してください/)).toBeInTheDocument()
+    })
+  })
+
+  // Note: input type="date" では不正な値は自動的にバリデーションされるため、このテストはスキップ
+
+  it('バリデーションエラーが発生しても入力値は維持される', async () => {
+    render(<SearchForm onSearch={mockOnSearch} />)
+
+    const shopNameInput = screen.getByLabelText('店舗名') as HTMLInputElement
+    const longName = 'あ'.repeat(101)
+
+    fireEvent.change(shopNameInput, { target: { value: longName } })
+    fireEvent.click(screen.getByRole('button', { name: '検索' }))
+
+    await waitFor(() => {
+      expect(shopNameInput.value).toBe(longName)
+    })
+  })
+})

--- a/__tests__/features/shop-search/components/SearchResults.test.tsx
+++ b/__tests__/features/shop-search/components/SearchResults.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SearchResults } from '@/features/shop-search/components/SearchResults'
+
+describe('SearchResults Component', () => {
+  const mockOnPageChange = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('検索結果が0件の場合はメッセージを表示', () => {
+    render(
+      <SearchResults
+        results={[]}
+        currentPage={1}
+        totalPages={0}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    expect(screen.getByText('検索に当てはまる店舗がありません。')).toBeInTheDocument()
+  })
+
+  it('検索結果が表示される', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗1',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+      {
+        id: 'shop-2',
+        shop_name: 'テスト店舗2',
+        business_hours_start: '10:00',
+        business_hours_end: '19:00',
+        reservation_hours_start: '10:00',
+        reservation_hours_end: '18:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={1}
+        totalPages={1}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    expect(screen.getByText('テスト店舗1')).toBeInTheDocument()
+    expect(screen.getByText('テスト店舗2')).toBeInTheDocument()
+    expect(screen.getByText(/営業時間: 09:00 - 18:00/)).toBeInTheDocument()
+    expect(screen.getByText(/営業時間: 10:00 - 19:00/)).toBeInTheDocument()
+  })
+
+  it('予約受付時間が表示される', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={1}
+        totalPages={1}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    expect(screen.getByText(/予約受付時間: 09:00 - 17:00/)).toBeInTheDocument()
+  })
+
+  it('予約ボタンが表示される', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={1}
+        totalPages={1}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '予約' })).toBeInTheDocument()
+  })
+
+  it('予約キャンセルボタンが表示される', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={1}
+        totalPages={1}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '予約キャンセル' })).toBeInTheDocument()
+  })
+
+  it('ページネーションが2ページ以上の場合に表示される', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={1}
+        totalPages={3}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '次へ' })).toBeInTheDocument()
+  })
+
+  it('ページネーションの次へボタンをクリックするとページが変わる', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={1}
+        totalPages={3}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    const nextButton = screen.getByRole('button', { name: '次へ' })
+    fireEvent.click(nextButton)
+
+    expect(mockOnPageChange).toHaveBeenCalledWith(2)
+  })
+
+  it('最終ページでは次へボタンが無効化される', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={3}
+        totalPages={3}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    const nextButton = screen.getByRole('button', { name: '次へ' })
+    expect(nextButton).toBeDisabled()
+  })
+
+  it('最初のページでは前へボタンが無効化される', () => {
+    const mockResults = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    render(
+      <SearchResults
+        results={mockResults}
+        currentPage={1}
+        totalPages={3}
+        onPageChange={mockOnPageChange}
+      />
+    )
+
+    const prevButton = screen.getByRole('button', { name: '前へ' })
+    expect(prevButton).toBeDisabled()
+  })
+})

--- a/__tests__/features/shop-search/utils/searchShops.test.ts
+++ b/__tests__/features/shop-search/utils/searchShops.test.ts
@@ -1,0 +1,262 @@
+import { searchShops } from '@/features/shop-search/utils/searchShops'
+import { createClient } from '@/lib/supabase/client'
+
+// モック
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(),
+}))
+
+describe('searchShops', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('店舗名のみで検索できる', async () => {
+    const mockData = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    const mockRange = jest.fn().mockResolvedValue({
+      data: mockData,
+      error: null,
+      count: 1,
+    })
+
+    const mockIlike = jest.fn().mockReturnValue({
+      range: mockRange,
+    })
+
+    const mockSelect = jest.fn().mockReturnValue({
+      ilike: mockIlike,
+    })
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: mockSelect,
+    })
+
+    ;(createClient as jest.Mock).mockReturnValue({
+      from: mockFrom,
+    })
+
+    const result = await searchShops({
+      shopName: 'テスト',
+      page: 1,
+      limit: 20,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(mockData)
+    expect(result.total).toBe(1)
+  })
+
+  it('日付と時間で検索できる', async () => {
+    const mockData = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+        business_days: ['月', '火', '水', '木', '金'],
+      },
+    ]
+
+    const mockRange = jest.fn().mockResolvedValue({
+      data: mockData,
+      error: null,
+      count: 1,
+    })
+
+    const mockContains = jest.fn().mockReturnValue({
+      range: mockRange,
+    })
+
+    const mockGte = jest.fn().mockReturnValue({
+      contains: mockContains,
+    })
+
+    const mockLte = jest.fn().mockReturnValue({
+      gte: mockGte,
+    })
+
+    const mockSelect = jest.fn().mockReturnValue({
+      lte: mockLte,
+    })
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: mockSelect,
+    })
+
+    ;(createClient as jest.Mock).mockReturnValue({
+      from: mockFrom,
+    })
+
+    const result = await searchShops({
+      date: '2025-12-22', // 月曜日
+      time: '10:00',
+      page: 1,
+      limit: 20,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(mockData)
+  })
+
+  it('検索条件なしで全件取得できる', async () => {
+    const mockData = [
+      {
+        id: 'shop-1',
+        shop_name: 'テスト店舗1',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+      {
+        id: 'shop-2',
+        shop_name: 'テスト店舗2',
+        business_hours_start: '10:00',
+        business_hours_end: '19:00',
+        reservation_hours_start: '10:00',
+        reservation_hours_end: '18:00',
+      },
+    ]
+
+    const mockRange = jest.fn().mockResolvedValue({
+      data: mockData,
+      error: null,
+      count: 2,
+    })
+
+    const mockSelect = jest.fn().mockReturnValue({
+      range: mockRange,
+    })
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: mockSelect,
+    })
+
+    ;(createClient as jest.Mock).mockReturnValue({
+      from: mockFrom,
+    })
+
+    const result = await searchShops({
+      page: 1,
+      limit: 20,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual(mockData)
+    expect(result.total).toBe(2)
+  })
+
+  it('ページネーションが正しく動作する', async () => {
+    const mockData = [
+      {
+        id: 'shop-21',
+        shop_name: 'テスト店舗21',
+        business_hours_start: '09:00',
+        business_hours_end: '18:00',
+        reservation_hours_start: '09:00',
+        reservation_hours_end: '17:00',
+      },
+    ]
+
+    const mockRange = jest.fn().mockResolvedValue({
+      data: mockData,
+      error: null,
+      count: 25,
+    })
+
+    const mockSelect = jest.fn().mockReturnValue({
+      range: mockRange,
+    })
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: mockSelect,
+    })
+
+    ;(createClient as jest.Mock).mockReturnValue({
+      from: mockFrom,
+    })
+
+    const result = await searchShops({
+      page: 2,
+      limit: 20,
+    })
+
+    expect(mockRange).toHaveBeenCalledWith(20, 39)
+    expect(result.success).toBe(true)
+    expect(result.totalPages).toBe(2) // 25件 / 20件 = 2ページ
+  })
+
+  it('データが0件の場合', async () => {
+    const mockRange = jest.fn().mockResolvedValue({
+      data: [],
+      error: null,
+      count: 0,
+    })
+
+    const mockIlike = jest.fn().mockReturnValue({
+      range: mockRange,
+    })
+
+    const mockSelect = jest.fn().mockReturnValue({
+      ilike: mockIlike,
+    })
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: mockSelect,
+    })
+
+    ;(createClient as jest.Mock).mockReturnValue({
+      from: mockFrom,
+    })
+
+    const result = await searchShops({
+      shopName: '存在しない店舗',
+      page: 1,
+      limit: 20,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual([])
+    expect(result.total).toBe(0)
+  })
+
+  it('エラーが発生した場合はエラーを返す', async () => {
+    const mockRange = jest.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'Database error' },
+      count: null,
+    })
+
+    const mockSelect = jest.fn().mockReturnValue({
+      range: mockRange,
+    })
+
+    const mockFrom = jest.fn().mockReturnValue({
+      select: mockSelect,
+    })
+
+    ;(createClient as jest.Mock).mockReturnValue({
+      from: mockFrom,
+    })
+
+    const result = await searchShops({
+      page: 1,
+      limit: 20,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('店舗の検索に失敗しました')
+  })
+})

--- a/__tests__/features/shop-search/utils/validateSearchForm.test.ts
+++ b/__tests__/features/shop-search/utils/validateSearchForm.test.ts
@@ -1,0 +1,104 @@
+import { validateSearchForm } from '@/features/shop-search/utils/validateSearchForm'
+
+describe('validateSearchForm', () => {
+  it('すべて空の場合は有効', () => {
+    const result = validateSearchForm({
+      shopName: '',
+      date: '',
+      time: '',
+    })
+
+    expect(result.isValid).toBe(true)
+    expect(result.errors).toEqual({})
+  })
+
+  it('店舗名が100文字以下の場合は有効', () => {
+    const result = validateSearchForm({
+      shopName: 'あ'.repeat(100),
+      date: '',
+      time: '',
+    })
+
+    expect(result.isValid).toBe(true)
+    expect(result.errors).toEqual({})
+  })
+
+  it('店舗名が101文字以上の場合は無効', () => {
+    const result = validateSearchForm({
+      shopName: 'あ'.repeat(101),
+      date: '',
+      time: '',
+    })
+
+    expect(result.isValid).toBe(false)
+    expect(result.errors.shopName).toBe('店舗名は100文字以下で入力してください。')
+  })
+
+  it('正しい日付形式の場合は有効', () => {
+    const result = validateSearchForm({
+      shopName: '',
+      date: '2025-12-20',
+      time: '',
+    })
+
+    expect(result.isValid).toBe(true)
+    expect(result.errors).toEqual({})
+  })
+
+  it('不正な日付形式の場合は無効', () => {
+    const result = validateSearchForm({
+      shopName: '',
+      date: 'invalid-date',
+      time: '',
+    })
+
+    expect(result.isValid).toBe(false)
+    expect(result.errors.date).toBe('正しい日付を入力してください。')
+  })
+
+  it('存在しない日付の場合は無効', () => {
+    const result = validateSearchForm({
+      shopName: '',
+      date: '2025-02-30', // 2月30日は存在しない
+      time: '',
+    })
+
+    expect(result.isValid).toBe(false)
+    expect(result.errors.date).toBe('正しい日付を入力してください。')
+  })
+
+  it('正しい時間形式の場合は有効', () => {
+    const result = validateSearchForm({
+      shopName: '',
+      date: '',
+      time: '10:00',
+    })
+
+    expect(result.isValid).toBe(true)
+    expect(result.errors).toEqual({})
+  })
+
+  it('不正な時間形式の場合は無効', () => {
+    const result = validateSearchForm({
+      shopName: '',
+      date: '',
+      time: '25:00',
+    })
+
+    expect(result.isValid).toBe(false)
+    expect(result.errors.time).toBe('正しい時間を入力してください。')
+  })
+
+  it('複数のエラーがある場合はすべて返す', () => {
+    const result = validateSearchForm({
+      shopName: 'あ'.repeat(101),
+      date: 'invalid',
+      time: '99:99',
+    })
+
+    expect(result.isValid).toBe(false)
+    expect(result.errors.shopName).toBe('店舗名は100文字以下で入力してください。')
+    expect(result.errors.date).toBe('正しい日付を入力してください。')
+    expect(result.errors.time).toBe('正しい時間を入力してください。')
+  })
+})

--- a/app/user/mypage/page.tsx
+++ b/app/user/mypage/page.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import { Header } from '@/components/user/Header'
+import { Footer } from '@/components/user/Footer'
+import { Sidebar } from '@/components/user/Sidebar'
+import { SearchForm } from '@/features/shop-search/components/SearchForm'
+import { SearchResults } from '@/features/shop-search/components/SearchResults'
+import type { Shop } from '@/features/shop-search/types'
+
+export default function MyPage() {
+  const router = useRouter()
+  const [userName, setUserName] = useState<string>('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [searchResults, setSearchResults] = useState<Shop[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(0)
+  const [lastSearchParams, setLastSearchParams] = useState<{
+    shopName?: string
+    date?: string
+    time?: string
+  }>({})
+
+  useEffect(() => {
+    const init = async () => {
+      const supabase = createClient()
+
+      // 認証チェック
+      const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+      if (authError || !user) {
+        router.push('/user/login')
+        return
+      }
+
+      // ユーザー名取得
+      const { data: userData, error: userError } = await supabase
+        .from('users')
+        .select('user_name')
+        .eq('id', user.id)
+        .single()
+
+      if (userError || !userData) {
+        console.error('Failed to fetch user data:', userError)
+        router.push('/user/login')
+        return
+      }
+
+      setUserName(userData.user_name)
+      setIsLoading(false)
+    }
+
+    init()
+  }, [router])
+
+  const handleSearch = (
+    results: Shop[],
+    page: number,
+    total: number,
+    searchParams?: { shopName?: string; date?: string; time?: string }
+  ) => {
+    setSearchResults(results)
+    setCurrentPage(page)
+    setTotalPages(total)
+    if (searchParams) {
+      setLastSearchParams(searchParams)
+    }
+  }
+
+  const handlePageChange = async (newPage: number) => {
+    const { searchShops } = await import('@/features/shop-search/utils/searchShops')
+    const result = await searchShops({
+      shopName: lastSearchParams.shopName,
+      date: lastSearchParams.date,
+      time: lastSearchParams.time,
+      page: newPage,
+      limit: 20,
+    })
+
+    if (result.success && result.data) {
+      setSearchResults(result.data)
+      setCurrentPage(newPage)
+      setTotalPages(result.totalPages || 0)
+    }
+  }
+
+  if (isLoading) {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header userName={userName} />
+
+      <div className="flex flex-1">
+        <Sidebar />
+
+        <main className="flex-1 container mx-auto px-4 py-8">
+          <h1 className="text-3xl font-bold text-gray-800 mb-6">
+            店舗検索
+          </h1>
+
+          <SearchForm onSearch={handleSearch} />
+
+          <SearchResults
+            results={searchResults}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </main>
+      </div>
+
+      <Footer />
+    </div>
+  )
+}

--- a/components/user/Footer.tsx
+++ b/components/user/Footer.tsx
@@ -1,0 +1,13 @@
+export function Footer() {
+  return (
+    <footer className="bg-gray-100 border-t border-gray-200 py-4 mt-auto">
+      <div className="container mx-auto px-4">
+        <div className="text-center text-sm text-gray-600">
+          <p>ユーザー向けマイページ</p>
+          <p>店舗予約システム</p>
+          <p className="mt-1">© 2025 店舗予約システム. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/user/Header.tsx
+++ b/components/user/Header.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { signOut } from '@/features/auth/utils/signOut'
+import { Button } from '@/components/ui/button'
+
+interface HeaderProps {
+  userName: string
+}
+
+export function Header({ userName }: HeaderProps) {
+  const router = useRouter()
+
+  const handleLogout = async () => {
+    const result = await signOut()
+    if (result.success) {
+      router.push('/user/signup')
+    }
+  }
+
+  return (
+    <header className="bg-white border-b border-gray-200 shadow-sm">
+      <div className="container mx-auto px-4 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="text-lg font-semibold text-gray-800">
+              {userName}
+            </div>
+          </div>
+          <div className="flex gap-4">
+            <Button
+              variant="outline"
+              onClick={handleLogout}
+            >
+              ログアウト
+            </Button>
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/user/Sidebar.tsx
+++ b/components/user/Sidebar.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { ChevronRight, ChevronLeft, History, Settings } from 'lucide-react'
+
+export function Sidebar() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleSidebar = () => {
+    setIsOpen(!isOpen)
+  }
+
+  return (
+    <aside
+      role="complementary"
+      className={`${
+        isOpen ? 'w-64' : 'w-16'
+      } bg-gray-50 border-r border-gray-200 transition-all duration-300 flex flex-col`}
+    >
+      {/* トグルボタン */}
+      <div className="p-4 border-b border-gray-200">
+        <button
+          onClick={toggleSidebar}
+          className="w-full flex items-center justify-center hover:bg-gray-200 rounded p-2 transition-colors"
+          aria-label={isOpen ? 'メニューを閉じる' : 'メニューを開く'}
+        >
+          {isOpen ? (
+            <ChevronLeft className="w-5 h-5" />
+          ) : (
+            <ChevronRight className="w-5 h-5" />
+          )}
+        </button>
+      </div>
+
+      {/* メニュー項目 */}
+      <div className="flex-1 p-4">
+        <nav className="space-y-2">
+          {/* 予約履歴リンク */}
+          <Link
+            href="/user/reservations"
+            className="flex items-center gap-3 p-2 hover:bg-gray-200 rounded transition-colors"
+          >
+            <History className="w-5 h-5 flex-shrink-0" />
+            {isOpen && <span className="text-sm">予約履歴</span>}
+          </Link>
+        </nav>
+      </div>
+
+      {/* ユーザー設定ボタン（下部） */}
+      <div className="p-4 border-t border-gray-200">
+        <Button
+          variant="outline"
+          className={`w-full ${isOpen ? 'justify-start' : 'justify-center px-2'}`}
+          disabled
+        >
+          <Settings className="w-5 h-5 flex-shrink-0" />
+          {isOpen && <span className="ml-2">ユーザー設定</span>}
+        </Button>
+      </div>
+    </aside>
+  )
+}

--- a/features/shop-search/components/SearchForm.tsx
+++ b/features/shop-search/components/SearchForm.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { searchShops } from '../utils/searchShops'
+import { validateSearchForm } from '../utils/validateSearchForm'
+import type { Shop } from '../types'
+
+interface SearchFormProps {
+  onSearch: (
+    results: Shop[],
+    page: number,
+    total: number,
+    searchParams?: { shopName?: string; date?: string; time?: string }
+  ) => void
+}
+
+// 30分単位の時間選択肢を生成
+const generateTimeOptions = () => {
+  const options = []
+  for (let hour = 0; hour < 24; hour++) {
+    for (let minute = 0; minute < 60; minute += 30) {
+      const timeStr = `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`
+      options.push(timeStr)
+    }
+  }
+  return options
+}
+
+// コンポーネント外で定数化（パフォーマンス最適化）
+const TIME_OPTIONS = generateTimeOptions()
+
+export function SearchForm({ onSearch }: SearchFormProps) {
+  const [shopName, setShopName] = useState('')
+  const [date, setDate] = useState('')
+  const [time, setTime] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [isSearching, setIsSearching] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setErrors({})
+    setIsSearching(true)
+
+    // バリデーション
+    const validation = validateSearchForm({ shopName, date, time })
+    if (!validation.isValid) {
+      setErrors(validation.errors)
+      setIsSearching(false)
+      return
+    }
+
+    // 検索実行
+    const searchParams = {
+      shopName: shopName || undefined,
+      date: date || undefined,
+      time: time || undefined,
+    }
+
+    const result = await searchShops({
+      ...searchParams,
+      page: 1,
+      limit: 20,
+    })
+
+    if (result.success && result.data) {
+      onSearch(result.data, 1, result.totalPages || 0, searchParams)
+    } else {
+      setErrors({ submit: result.error || '検索に失敗しました' })
+    }
+
+    setIsSearching(false)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-6 mb-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+        {/* 店舗名 */}
+        <div className="space-y-2">
+          <Label htmlFor="shopName">店舗名</Label>
+          <Input
+            id="shopName"
+            type="text"
+            value={shopName}
+            onChange={(e) => setShopName(e.target.value)}
+            placeholder="店舗名を入力"
+            aria-invalid={!!errors.shopName}
+          />
+          {errors.shopName && (
+            <p className="text-sm text-red-600">{errors.shopName}</p>
+          )}
+        </div>
+
+        {/* 日付 */}
+        <div className="space-y-2">
+          <Label htmlFor="date">日付</Label>
+          <Input
+            id="date"
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            aria-invalid={!!errors.date}
+          />
+          {errors.date && (
+            <p className="text-sm text-red-600">{errors.date}</p>
+          )}
+        </div>
+
+        {/* 時間 */}
+        <div className="space-y-2">
+          <Label htmlFor="time">時間</Label>
+          <select
+            id="time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-invalid={!!errors.time}
+          >
+            <option value="">選択してください</option>
+            {TIME_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          {errors.time && (
+            <p className="text-sm text-red-600">{errors.time}</p>
+          )}
+        </div>
+      </div>
+
+      {/* エラーメッセージ */}
+      {errors.submit && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+          <p className="text-sm text-red-600">{errors.submit}</p>
+        </div>
+      )}
+
+      {/* 検索ボタン */}
+      <Button type="submit" disabled={isSearching} className="w-full md:w-auto">
+        {isSearching ? '検索中...' : '検索'}
+      </Button>
+    </form>
+  )
+}

--- a/features/shop-search/components/SearchResults.tsx
+++ b/features/shop-search/components/SearchResults.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import type { Shop } from '../types'
+
+interface SearchResultsProps {
+  results: Shop[]
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export function SearchResults({
+  results,
+  currentPage,
+  totalPages,
+  onPageChange,
+}: SearchResultsProps) {
+  if (results.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow p-6">
+        <p className="text-gray-600 text-center py-8">
+          検索に当てはまる店舗がありません。
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 検索結果一覧 */}
+      <div className="space-y-4">
+        {results.map((shop) => (
+          <div
+            key={shop.id}
+            className="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow"
+          >
+            <h3 className="text-xl font-semibold text-gray-800 mb-3">
+              {shop.shop_name}
+            </h3>
+
+            <div className="space-y-2 mb-4">
+              <p className="text-sm text-gray-600">
+                営業時間: {shop.business_hours_start} - {shop.business_hours_end}
+              </p>
+              <p className="text-sm text-gray-600">
+                予約受付時間: {shop.reservation_hours_start} -{' '}
+                {shop.reservation_hours_end}
+              </p>
+            </div>
+
+            <div className="flex gap-3">
+              <Button
+                variant="default"
+                className="bg-blue-600 hover:bg-blue-700"
+                disabled
+              >
+                予約
+              </Button>
+              <Button variant="outline" disabled>
+                予約キャンセル
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ページネーション */}
+      {totalPages > 1 && (
+        <div className="flex justify-center items-center gap-4">
+          <Button
+            variant="outline"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+          >
+            前へ
+          </Button>
+
+          <span className="text-sm text-gray-600">
+            {currentPage} / {totalPages} ページ
+          </span>
+
+          <Button
+            variant="outline"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+          >
+            次へ
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/features/shop-search/types/index.ts
+++ b/features/shop-search/types/index.ts
@@ -1,0 +1,32 @@
+// Shop型定義
+export interface Shop {
+  id: string
+  owner_id: string
+  shop_name: string
+  business_hours_start: string
+  business_hours_end: string
+  reservation_hours_start: string
+  reservation_hours_end: string
+  business_days: string[]
+  closed_days: string[]
+  created_at: string
+  updated_at: string
+}
+
+// 検索パラメータ
+export interface SearchParams {
+  shopName?: string
+  date?: string
+  time?: string
+  page: number
+  limit: number
+}
+
+// 検索結果
+export interface SearchResult {
+  success: boolean
+  data?: Shop[]
+  total?: number
+  totalPages?: number
+  error?: string
+}

--- a/features/shop-search/utils/searchShops.ts
+++ b/features/shop-search/utils/searchShops.ts
@@ -1,0 +1,74 @@
+import { createClient } from '@/lib/supabase/client'
+import type { SearchParams, SearchResult, Shop } from '../types'
+
+// 曜日マッピング（日曜日=0, 月曜日=1, ...）
+const WEEKDAY_MAP: Record<number, string> = {
+  0: '日',
+  1: '月',
+  2: '火',
+  3: '水',
+  4: '木',
+  5: '金',
+  6: '土',
+}
+
+export async function searchShops(params: SearchParams): Promise<SearchResult> {
+  try {
+    const supabase = createClient()
+    const { shopName, date, time, page, limit } = params
+
+    // ページネーション計算
+    const from = (page - 1) * limit
+    const to = from + limit - 1
+
+    let query = supabase
+      .from('shops')
+      .select('*', { count: 'exact' })
+
+    // 店舗名検索（部分一致）
+    if (shopName) {
+      query = query.ilike('shop_name', `%${shopName}%`)
+    }
+
+    // 時間検索（予約受付時間内）
+    if (time) {
+      query = query.lte('reservation_hours_start', time)
+      query = query.gte('reservation_hours_end', time)
+    }
+
+    // 日付による営業日フィルタリング（データベース側）
+    // NOTE: Supabaseのarray型に対するcontains演算子を使用
+    if (date) {
+      const dateObj = new Date(date)
+      const dayOfWeek = WEEKDAY_MAP[dateObj.getDay()]
+      query = query.contains('business_days', [dayOfWeek])
+    }
+
+    // ページネーション適用
+    const { data, error, count } = await query.range(from, to)
+
+    if (error) {
+      console.error('Shop search error:', error)
+      return {
+        success: false,
+        error: '店舗の検索に失敗しました',
+      }
+    }
+
+    const totalCount = count || 0
+    const totalPages = Math.ceil(totalCount / limit)
+
+    return {
+      success: true,
+      data: (data || []) as Shop[],
+      total: totalCount,
+      totalPages,
+    }
+  } catch (error) {
+    console.error('Unexpected error during shop search:', error)
+    return {
+      success: false,
+      error: '店舗検索中にエラーが発生しました',
+    }
+  }
+}

--- a/features/shop-search/utils/validateSearchForm.ts
+++ b/features/shop-search/utils/validateSearchForm.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+export const searchFormSchema = z.object({
+  shopName: z
+    .string()
+    .max(100, '店舗名は100文字以下で入力してください。')
+    .optional()
+    .or(z.literal('')),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, '正しい日付を入力してください。')
+    .refine((val) => {
+      if (!val) return true
+      const dateObj = new Date(val)
+      const [year, month, day] = val.split('-').map(Number)
+      return (
+        dateObj.getFullYear() === year &&
+        dateObj.getMonth() + 1 === month &&
+        dateObj.getDate() === day
+      )
+    }, '正しい日付を入力してください。')
+    .optional()
+    .or(z.literal('')),
+  time: z
+    .string()
+    .regex(/^([0-1]\d|2[0-3]):([0-5]\d)$/, '正しい時間を入力してください。')
+    .optional()
+    .or(z.literal('')),
+})
+
+export type SearchFormData = z.infer<typeof searchFormSchema>
+
+interface ValidationResult {
+  isValid: boolean
+  errors: Record<string, string>
+}
+
+export function validateSearchForm(data: SearchFormData): ValidationResult {
+  const result = searchFormSchema.safeParse(data)
+
+  if (result.success) {
+    return {
+      isValid: true,
+      errors: {},
+    }
+  }
+
+  const errors: Record<string, string> = {}
+  result.error.errors.forEach((err) => {
+    const field = err.path[0] as string
+    errors[field] = err.message
+  })
+
+  return {
+    isValid: false,
+    errors,
+  }
+}


### PR DESCRIPTION
ユーザーが店舗を検索・閲覧できるマイページを実装しました。

- ユーザー向けヘッダー・フッター・サイドメニュー
- 店舗検索フォーム（店舗名、日付、時間）
- Zodバリデーション
- ページネーション（20件/ページ）
- 検索結果表示
- 型定義の整備（any型を排除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)