### PR TITLE
feat: ユーザー設定ページの実装 (Issue #17)

### DIFF
--- a/__tests__/app/user/mypage/page.test.tsx
+++ b/__tests__/app/user/mypage/page.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { useRouter } from 'next/navigation'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import MyPage from '@/app/user/mypage/page'
 import { createClient } from '@/lib/supabase/client'
 
 // モック
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
 }))
 
 jest.mock('@/lib/supabase/client', () => ({
@@ -36,6 +37,9 @@ jest.mock('@/features/shop-search/components/SearchResults', () => ({
 
 describe('User MyPage', () => {
   const mockPush = jest.fn()
+  const mockSearchParams = {
+    get: jest.fn(),
+  }
   const mockSupabase = {
     auth: {
       getUser: jest.fn(),
@@ -45,10 +49,18 @@ describe('User MyPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers()
     ;(useRouter as jest.Mock).mockReturnValue({
       push: mockPush,
     })
+    ;(useSearchParams as jest.Mock).mockReturnValue(mockSearchParams)
     ;(createClient as jest.Mock).mockReturnValue(mockSupabase)
+    mockSearchParams.get.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
   })
 
   it('認証されていない場合はログインページへリダイレクトする', async () => {
@@ -124,5 +136,108 @@ describe('User MyPage', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/user/login')
     })
+  })
+
+  it('should display success message when updated=true query parameter is present', async () => {
+    mockSearchParams.get.mockReturnValue('true')
+
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_name: 'テストユーザー' },
+            error: null,
+          }),
+        }),
+      }),
+    })
+
+    render(<MyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ユーザー情報を更新しました')).toBeInTheDocument()
+    })
+  })
+
+  it('should auto-dismiss success message after 3 seconds', async () => {
+    mockSearchParams.get.mockReturnValue('true')
+
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_name: 'テストユーザー' },
+            error: null,
+          }),
+        }),
+      }),
+    })
+
+    render(<MyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ユーザー情報を更新しました')).toBeInTheDocument()
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('ユーザー情報を更新しました')).not.toBeInTheDocument()
+    })
+  })
+
+  it('should not display success message when updated query parameter is not present', async () => {
+    mockSearchParams.get.mockReturnValue(null)
+
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { user_name: 'テストユーザー' },
+            error: null,
+          }),
+        }),
+      }),
+    })
+
+    render(<MyPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('header')).toHaveTextContent('テストユーザー')
+    })
+
+    expect(screen.queryByText('ユーザー情報を更新しました')).not.toBeInTheDocument()
   })
 })

--- a/__tests__/app/user/settings/page.test.tsx
+++ b/__tests__/app/user/settings/page.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { useRouter } from 'next/navigation'
+import UserSettingsPage from '@/app/user/settings/page'
+import { createClient } from '@/lib/supabase/client'
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(),
+}))
+
+jest.mock('@/components/user/Header', () => ({
+  Header: () => <div data-testid="mock-header">Header</div>,
+}))
+
+jest.mock('@/components/user/Footer', () => ({
+  Footer: () => <div data-testid="mock-footer">Footer</div>,
+}))
+
+jest.mock('@/components/user/Sidebar', () => ({
+  Sidebar: () => <div data-testid="mock-sidebar">Sidebar</div>,
+}))
+
+jest.mock('@/features/auth/components/UserSettingsForm', () => ({
+  UserSettingsForm: ({ userId, defaultValues, onSuccess, onCancel }: any) => (
+    <div data-testid="mock-settings-form">
+      <p>UserId: {userId}</p>
+      <p>UserName: {defaultValues.userName}</p>
+      <p>Email: {defaultValues.email}</p>
+      <button onClick={onSuccess}>Save</button>
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}))
+
+const mockPush = jest.fn()
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>
+
+describe('UserSettingsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+    } as any)
+  })
+
+  it('should redirect to login if not authenticated', async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+    }
+    mockCreateClient.mockReturnValue(mockSupabase as any)
+
+    render(<UserSettingsPage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/login')
+    })
+  })
+
+  it('should display loading state initially', () => {
+    const mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'test-user-id' } },
+        }),
+      },
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_name: 'testuser', email: 'test@example.com' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    }
+    mockCreateClient.mockReturnValue(mockSupabase as any)
+
+    render(<UserSettingsPage />)
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+  })
+
+  it('should render the settings form with user data', async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'test-user-id' } },
+        }),
+      },
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_name: 'testuser', email: 'test@example.com' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    }
+    mockCreateClient.mockReturnValue(mockSupabase as any)
+
+    render(<UserSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-settings-form')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('UserId: test-user-id')).toBeInTheDocument()
+    expect(screen.getByText('UserName: testuser')).toBeInTheDocument()
+    expect(screen.getByText('Email: test@example.com')).toBeInTheDocument()
+  })
+
+  it('should redirect to mypage with updated=true on success', async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'test-user-id' } },
+        }),
+      },
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_name: 'testuser', email: 'test@example.com' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    }
+    mockCreateClient.mockReturnValue(mockSupabase as any)
+
+    render(<UserSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-settings-form')).toBeInTheDocument()
+    })
+
+    const saveButton = screen.getByText('Save')
+    saveButton.click()
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/mypage?updated=true')
+    })
+  })
+
+  it('should redirect to mypage on cancel', async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'test-user-id' } },
+        }),
+      },
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: { user_name: 'testuser', email: 'test@example.com' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    }
+    mockCreateClient.mockReturnValue(mockSupabase as any)
+
+    render(<UserSettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-settings-form')).toBeInTheDocument()
+    })
+
+    const cancelButton = screen.getByText('Cancel')
+    cancelButton.click()
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/mypage')
+    })
+  })
+
+  it('should redirect to mypage if user data fetch fails', async () => {
+    const mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'test-user-id' } },
+        }),
+      },
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'User not found' },
+            }),
+          }),
+        }),
+      }),
+    }
+    mockCreateClient.mockReturnValue(mockSupabase as any)
+
+    render(<UserSettingsPage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/mypage')
+    })
+  })
+})

--- a/__tests__/components/user/Sidebar.test.tsx
+++ b/__tests__/components/user/Sidebar.test.tsx
@@ -44,19 +44,33 @@ describe('User Sidebar Component', () => {
     expect(screen.getByText('予約履歴')).toBeInTheDocument()
   })
 
-  it('サイドバーが開いている時にユーザー設定ボタンが表示される', () => {
+  it('サイドバーが開いている時にユーザー設定リンクが表示される', () => {
     render(<Sidebar />)
 
     const toggleButton = screen.getByRole('button', { name: /メニューを開く|メニューを閉じる/ })
     fireEvent.click(toggleButton)
 
-    expect(screen.getByRole('button', { name: 'ユーザー設定' })).toBeInTheDocument()
+    expect(screen.getByText('ユーザー設定')).toBeInTheDocument()
+  })
+
+  it('ユーザー設定リンクが正しいURLを持つ', () => {
+    render(<Sidebar />)
+
+    const settingsLink = screen.getByRole('link', { name: /ユーザー設定/i })
+    expect(settingsLink).toHaveAttribute('href', '/user/settings')
+  })
+
+  it('予約履歴リンクが正しいURLを持つ', () => {
+    render(<Sidebar />)
+
+    const reservationsLink = screen.getByRole('link', { name: /予約履歴/i })
+    expect(reservationsLink).toHaveAttribute('href', '/user/reservations')
   })
 
   it('サイドバーが閉じている時はテキストが表示されない', () => {
     render(<Sidebar />)
 
     expect(screen.queryByText('予約履歴')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'ユーザー設定' })).not.toBeInTheDocument()
+    expect(screen.queryByText('ユーザー設定')).not.toBeInTheDocument()
   })
 })

--- a/__tests__/features/auth/components/UserSettingsForm.test.tsx
+++ b/__tests__/features/auth/components/UserSettingsForm.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { UserSettingsForm } from '@/features/auth/components/UserSettingsForm'
+import { updateUserInfo } from '@/features/auth/utils/userAuth'
+
+jest.mock('@/features/auth/utils/userAuth')
+
+const mockUpdateUserInfo = updateUserInfo as jest.MockedFunction<typeof updateUserInfo>
+
+describe('UserSettingsForm', () => {
+  const mockUserId = 'test-user-id'
+  const mockDefaultValues = {
+    userName: 'testuser',
+    email: 'test@example.com',
+  }
+  const mockOnSuccess = jest.fn()
+  const mockOnCancel = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render the form with default values', () => {
+    render(
+      <UserSettingsForm
+        userId={mockUserId}
+        defaultValues={mockDefaultValues}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const userNameInput = screen.getByLabelText('ユーザー名')
+    const emailInput = screen.getByLabelText('メールアドレス')
+
+    expect(userNameInput).toHaveValue('testuser')
+    expect(emailInput).toHaveValue('test@example.com')
+  })
+
+  it('should display validation error for invalid userName', async () => {
+    const user = userEvent.setup()
+    render(
+      <UserSettingsForm
+        userId={mockUserId}
+        defaultValues={{ userName: 'ab', email: 'test@example.com' }}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('ユーザー名は3文字以上で入力してください')).toBeInTheDocument()
+    })
+
+    expect(mockUpdateUserInfo).not.toHaveBeenCalled()
+  })
+
+  it('should call updateUserInfo and onSuccess on valid submission', async () => {
+    mockUpdateUserInfo.mockResolvedValue({ success: true })
+
+    const user = userEvent.setup()
+    render(
+      <UserSettingsForm
+        userId={mockUserId}
+        defaultValues={mockDefaultValues}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const userNameInput = screen.getByLabelText('ユーザー名')
+    const emailInput = screen.getByLabelText('メールアドレス')
+
+    await user.clear(userNameInput)
+    await user.type(userNameInput, 'newusername')
+    await user.clear(emailInput)
+    await user.type(emailInput, 'newemail@example.com')
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockUpdateUserInfo).toHaveBeenCalledWith(mockUserId, {
+        userName: 'newusername',
+        email: 'newemail@example.com',
+      })
+    })
+
+    expect(mockOnSuccess).toHaveBeenCalled()
+  })
+
+  it('should display error message on update failure', async () => {
+    mockUpdateUserInfo.mockResolvedValue({
+      success: false,
+      error: 'ユーザー情報の更新に失敗しました',
+    })
+
+    const user = userEvent.setup()
+    render(
+      <UserSettingsForm
+        userId={mockUserId}
+        defaultValues={mockDefaultValues}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('ユーザー情報の更新に失敗しました')).toBeInTheDocument()
+    })
+
+    expect(mockOnSuccess).not.toHaveBeenCalled()
+  })
+
+  it('should call onCancel when cancel button is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <UserSettingsForm
+        userId={mockUserId}
+        defaultValues={mockDefaultValues}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const cancelButton = screen.getByRole('button', { name: 'キャンセル' })
+    await user.click(cancelButton)
+
+    expect(mockOnCancel).toHaveBeenCalled()
+    expect(mockUpdateUserInfo).not.toHaveBeenCalled()
+  })
+
+  it('should disable buttons while loading', async () => {
+    mockUpdateUserInfo.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve({ success: true }), 100))
+    )
+
+    const user = userEvent.setup()
+    render(
+      <UserSettingsForm
+        userId={mockUserId}
+        defaultValues={mockDefaultValues}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const submitButton = screen.getByRole('button', { name: '保存' })
+    const cancelButton = screen.getByRole('button', { name: 'キャンセル' })
+
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '保存中...' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'キャンセル' })).toBeDisabled()
+    })
+  })
+})

--- a/__tests__/features/auth/utils/userAuth.updateUserInfo.test.ts
+++ b/__tests__/features/auth/utils/userAuth.updateUserInfo.test.ts
@@ -1,0 +1,134 @@
+import { updateUserInfo } from '@/features/auth/utils/userAuth'
+import { createClient } from '@/lib/supabase/client'
+
+jest.mock('@/lib/supabase/client')
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>
+
+describe('updateUserInfo', () => {
+  let mockSupabase: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSupabase = {
+      from: jest.fn(),
+      auth: {
+        updateUser: jest.fn(),
+      },
+    }
+    mockCreateClient.mockReturnValue(mockSupabase)
+  })
+
+  it('should successfully update user info', async () => {
+    mockSupabase.from.mockReturnValue({
+      update: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({
+          error: null,
+        }),
+      }),
+    })
+    mockSupabase.auth.updateUser.mockResolvedValue({ error: null })
+
+    const result = await updateUserInfo('test-user-id', {
+      userName: 'newusername',
+      email: 'newemail@example.com',
+    })
+
+    expect(result.success).toBe(true)
+    expect(mockSupabase.from).toHaveBeenCalledWith('users')
+    expect(mockSupabase.auth.updateUser).toHaveBeenCalledWith({
+      email: 'newemail@example.com',
+    })
+  })
+
+  it('should return error when users table update fails', async () => {
+    mockSupabase.from.mockReturnValue({
+      update: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({
+          error: { message: 'Update failed' },
+        }),
+      }),
+    })
+
+    const result = await updateUserInfo('test-user-id', {
+      userName: 'newusername',
+      email: 'newemail@example.com',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('ユーザー情報の更新に失敗しました')
+  })
+
+  it('should return error for validation failure - userName too short', async () => {
+    const result = await updateUserInfo('test-user-id', {
+      userName: 'ab',
+      email: 'test@example.com',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('ユーザー名は3文字以上で入力してください')
+  })
+
+  it('should return error for validation failure - invalid email', async () => {
+    const result = await updateUserInfo('test-user-id', {
+      userName: 'validusername',
+      email: 'invalid-email',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('正しいメールアドレス形式で入力してください')
+  })
+
+  it('should return error for validation failure - userName with invalid characters', async () => {
+    const result = await updateUserInfo('test-user-id', {
+      userName: 'invalid-user@name',
+      email: 'test@example.com',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('ユーザー名は半角英数字とアンダースコアのみ使用できます')
+  })
+
+  it('should succeed even if auth email update fails', async () => {
+    mockSupabase.from.mockReturnValue({
+      update: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({
+          error: null,
+        }),
+      }),
+    })
+    mockSupabase.auth.updateUser.mockResolvedValue({
+      error: { message: 'Auth update failed' },
+    })
+
+    const result = await updateUserInfo('test-user-id', {
+      userName: 'newusername',
+      email: 'newemail@example.com',
+    })
+
+    // Should still succeed since users table was updated
+    expect(result.success).toBe(true)
+  })
+
+  it('should trim whitespace from userName and email', async () => {
+    const mockUpdate = jest.fn().mockReturnValue({
+      eq: jest.fn().mockResolvedValue({
+        error: null,
+      }),
+    })
+    mockSupabase.from.mockReturnValue({
+      update: mockUpdate,
+    })
+    mockSupabase.auth.updateUser.mockResolvedValue({ error: null })
+
+    await updateUserInfo('test-user-id', {
+      userName: '  testuser  ',
+      email: '  test@example.com  ',
+    })
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      user_name: 'testuser',
+      email: 'test@example.com',
+    })
+  })
+})

--- a/app/user/mypage/page.tsx
+++ b/app/user/mypage/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { Header } from '@/components/user/Header'
 import { Footer } from '@/components/user/Footer'
@@ -12,6 +12,7 @@ import type { Shop } from '@/features/shop-search/types'
 
 export default function MyPage() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [userName, setUserName] = useState<string>('')
   const [isLoading, setIsLoading] = useState(true)
   const [searchResults, setSearchResults] = useState<Shop[]>([])
@@ -22,6 +23,7 @@ export default function MyPage() {
     date?: string
     time?: string
   }>({})
+  const [showSuccessMessage, setShowSuccessMessage] = useState(false)
 
   useEffect(() => {
     const init = async () => {
@@ -54,6 +56,18 @@ export default function MyPage() {
 
     init()
   }, [router])
+
+  // Success message handling
+  useEffect(() => {
+    if (searchParams.get('updated') === 'true') {
+      setShowSuccessMessage(true)
+      // Auto-dismiss after 3 seconds
+      const timer = setTimeout(() => {
+        setShowSuccessMessage(false)
+      }, 3000)
+      return () => clearTimeout(timer)
+    }
+  }, [searchParams])
 
   const handleSearch = (
     results: Shop[],
@@ -98,6 +112,15 @@ export default function MyPage() {
         <Sidebar />
 
         <main className="flex-1 container mx-auto px-4 py-8">
+          {showSuccessMessage && (
+            <div
+              className="mb-4 p-4 bg-green-50 border border-green-200 text-green-800 rounded-md"
+              role="alert"
+            >
+              ユーザー情報を更新しました
+            </div>
+          )}
+
           <h1 className="text-3xl font-bold text-gray-800 mb-6">
             店舗検索
           </h1>

--- a/app/user/settings/page.tsx
+++ b/app/user/settings/page.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import { Header } from '@/components/user/Header'
+import { Footer } from '@/components/user/Footer'
+import { Sidebar } from '@/components/user/Sidebar'
+import { UserSettingsForm } from '@/features/auth/components/UserSettingsForm'
+import type { UserSettingsInput } from '@/features/auth/utils/validation'
+
+export default function UserSettingsPage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [userId, setUserId] = useState<string | null>(null)
+  const [userSettings, setUserSettings] = useState<UserSettingsInput | null>(null)
+
+  useEffect(() => {
+    const checkAuthAndFetchUser = async () => {
+      const supabase = createClient()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      if (!user) {
+        router.push('/user/login')
+        return
+      }
+
+      // Fetch current user data from users table
+      const { data: userData, error } = await supabase
+        .from('users')
+        .select('user_name, email')
+        .eq('id', user.id)
+        .single()
+
+      if (error || !userData) {
+        console.error('Failed to fetch user data:', error)
+        router.push('/user/mypage')
+        return
+      }
+
+      setUserId(user.id)
+      setUserSettings({
+        userName: userData.user_name,
+        email: userData.email,
+      })
+      setLoading(false)
+    }
+
+    checkAuthAndFetchUser()
+  }, [router])
+
+  const handleSuccess = () => {
+    router.push('/user/mypage?updated=true')
+  }
+
+  const handleCancel = () => {
+    router.push('/user/mypage')
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>読み込み中...</p>
+      </div>
+    )
+  }
+
+  if (!userId || !userSettings) {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <div className="flex-1 flex">
+        <Sidebar />
+        <main className="flex-1 p-8">
+          <div className="max-w-2xl mx-auto">
+            <div className="bg-white shadow-md rounded-lg p-8">
+              <div className="mb-6">
+                <h1 className="text-2xl font-bold text-gray-900">ユーザー情報編集</h1>
+                <p className="mt-2 text-sm text-gray-600">
+                  ユーザー名とメールアドレスを変更できます
+                </p>
+              </div>
+
+              <UserSettingsForm
+                userId={userId}
+                defaultValues={userSettings}
+                onSuccess={handleSuccess}
+                onCancel={handleCancel}
+              />
+            </div>
+          </div>
+        </main>
+      </div>
+      <Footer />
+    </div>
+  )
+}

--- a/components/user/Sidebar.tsx
+++ b/components/user/Sidebar.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { Button } from '@/components/ui/button'
 import { ChevronRight, ChevronLeft, History, Settings } from 'lucide-react'
 
 export function Sidebar() {
@@ -48,16 +47,15 @@ export function Sidebar() {
         </nav>
       </div>
 
-      {/* ユーザー設定ボタン（下部） */}
+      {/* ユーザー設定リンク（下部） */}
       <div className="p-4 border-t border-gray-200">
-        <Button
-          variant="outline"
-          className={`w-full ${isOpen ? 'justify-start' : 'justify-center px-2'}`}
-          disabled
+        <Link
+          href="/user/settings"
+          className="flex items-center gap-3 p-2 hover:bg-gray-200 rounded transition-colors border border-gray-300"
         >
           <Settings className="w-5 h-5 flex-shrink-0" />
-          {isOpen && <span className="ml-2">ユーザー設定</span>}
-        </Button>
+          {isOpen && <span className="text-sm">ユーザー設定</span>}
+        </Link>
       </div>
     </aside>
   )

--- a/features/auth/components/UserSettingsForm.tsx
+++ b/features/auth/components/UserSettingsForm.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { userSettingsSchema, type UserSettingsInput } from '../utils/validation'
+import { useState } from 'react'
+import { updateUserInfo } from '../utils/userAuth'
+
+interface UserSettingsFormProps {
+  userId: string
+  defaultValues: UserSettingsInput
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+export function UserSettingsForm({
+  userId,
+  defaultValues,
+  onSuccess,
+  onCancel,
+}: UserSettingsFormProps) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UserSettingsInput>({
+    resolver: zodResolver(userSettingsSchema),
+    defaultValues,
+  })
+
+  const onSubmit = async (data: UserSettingsInput) => {
+    setIsLoading(true)
+    setSubmitError(null)
+
+    const result = await updateUserInfo(userId, data)
+
+    setIsLoading(false)
+
+    if (result.success) {
+      onSuccess()
+    } else {
+      setSubmitError(result.error || 'ユーザー情報の更新に失敗しました')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="userName">ユーザー名</Label>
+        <Input
+          id="userName"
+          type="text"
+          placeholder="ユーザー名を入力"
+          {...register('userName')}
+          aria-invalid={errors.userName ? 'true' : 'false'}
+          aria-describedby={errors.userName ? 'userName-error' : undefined}
+        />
+        {errors.userName && (
+          <p id="userName-error" className="text-sm text-destructive" role="alert">
+            {errors.userName.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="email">メールアドレス</Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="email@example.com"
+          {...register('email')}
+          aria-invalid={errors.email ? 'true' : 'false'}
+          aria-describedby={errors.email ? 'email-error' : undefined}
+        />
+        {errors.email && (
+          <p id="email-error" className="text-sm text-destructive" role="alert">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      {submitError && (
+        <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md" role="alert">
+          {submitError}
+        </div>
+      )}
+
+      <div className="flex gap-4">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          onClick={onCancel}
+          disabled={isLoading}
+        >
+          キャンセル
+        </Button>
+        <Button type="submit" className="flex-1" disabled={isLoading}>
+          {isLoading ? '保存中...' : '保存'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/features/auth/types/index.ts
+++ b/features/auth/types/index.ts
@@ -9,6 +9,11 @@ export interface SignInData {
   password: string
 }
 
+export interface UserInfoUpdateData {
+  userName: string
+  email: string
+}
+
 export interface AuthResult {
   success: boolean
   error?: string

--- a/features/auth/utils/validation.ts
+++ b/features/auth/utils/validation.ts
@@ -1,23 +1,35 @@
 import { z } from 'zod'
 
-export const signUpSchema = z.object({
-  userName: z
-    .string()
-    .trim()
-    .min(3, 'ユーザー名は3文字以上で入力してください')
-    .max(50, 'ユーザー名は50文字以内で入力してください')
-    .regex(/^[a-zA-Z0-9_]+$/, 'ユーザー名は半角英数字とアンダースコアのみ使用できます'),
-  email: z
-    .string()
-    .trim()
-    .min(1, 'メールアドレスを入力してください')
-    .email('正しいメールアドレス形式で入力してください'),
+// 共通のユーザ名バリデーション
+export const userNameSchema = z
+  .string()
+  .trim()
+  .min(3, 'ユーザー名は3文字以上で入力してください')
+  .max(50, 'ユーザー名は50文字以内で入力してください')
+  .regex(/^[a-zA-Z0-9_]+$/, 'ユーザー名は半角英数字とアンダースコアのみ使用できます')
+
+// 共通のメールアドレスバリデーション
+export const emailSchema = z
+  .string()
+  .trim()
+  .min(1, 'メールアドレスを入力してください')
+  .email('正しいメールアドレス形式で入力してください')
+
+// 共通のユーザ情報スキーマ（ユーザ名とメールアドレス）
+export const userInfoSchema = z.object({
+  userName: userNameSchema,
+  email: emailSchema,
+})
+
+// サインアップ用スキーマ（ユーザ情報 + パスワード）
+export const signUpSchema = userInfoSchema.extend({
   password: z
     .string()
     .min(8, 'パスワードは8文字以上で入力してください')
     .max(100, 'パスワードは100文字以内で入力してください'),
 })
 
+// サインイン用スキーマ
 export const signInSchema = z.object({
   emailOrUserName: z
     .string()
@@ -27,5 +39,10 @@ export const signInSchema = z.object({
     .min(1, 'パスワードを入力してください'),
 })
 
+// ユーザ情報編集用スキーマ（ユーザ名とメールアドレスのみ）
+export const userSettingsSchema = userInfoSchema
+
+export type UserInfoInput = z.infer<typeof userInfoSchema>
 export type SignUpInput = z.infer<typeof signUpSchema>
 export type SignInInput = z.infer<typeof signInSchema>
+export type UserSettingsInput = z.infer<typeof userSettingsSchema>


### PR DESCRIPTION
## 実装内容

### バックエンド
- バリデーションスキーマの共通化（userName, email, userInfoSchema）
- updateUserInfo関数の追加（users テーブルと Supabase Auth の更新）
- UserInfoUpdateData 型の追加

### UI コンポーネント
- UserSettingsForm: ユーザー名とメールアドレス編集フォーム
- /user/settings: ユーザー設定ページ
- Sidebar: 設定リンクを有効化
- マイページ: 更新成功メッセージ表示機能（3秒後自動非表示）

### テスト
- UserSettingsForm コンポーネントテスト (6 tests)
- updateUserInfo 関数テスト (7 tests)
- ユーザー設定ページテスト (6 tests)
- Sidebar テスト更新 (3 tests)
- マイページテスト更新 (3 tests)

すべてのテストがパス（25 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)