### PR TITLE
feat: ユーザー予約機能の実装 (Issue #19)

### DIFF
--- a/__tests__/app/user/reservation/[shopId]/page.test.tsx
+++ b/__tests__/app/user/reservation/[shopId]/page.test.tsx
@@ -1,0 +1,295 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { useRouter, useParams } from 'next/navigation'
+import ReservationPage from '@/app/user/reservation/[shopId]/page'
+import { createClient } from '@/lib/supabase/client'
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useParams: jest.fn(),
+}))
+
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(),
+}))
+
+jest.mock('@/features/reservation/components/ReservationForm', () => ({
+  ReservationForm: ({
+    onSuccess,
+    onCancel,
+  }: {
+    onSuccess: () => void
+    onCancel: () => void
+  }) => (
+    <div data-testid="reservation-form">
+      <button onClick={onSuccess}>Success</button>
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}))
+
+describe('ReservationPage', () => {
+  const mockPush = jest.fn()
+  const mockSupabase = {
+    auth: {
+      getUser: jest.fn(),
+    },
+    from: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+    })
+    ;(useParams as jest.Mock).mockReturnValue({
+      shopId: 'shop-123',
+    })
+    ;(createClient as jest.Mock).mockReturnValue(mockSupabase)
+  })
+
+  it('should redirect to login if not authenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error('Not authenticated'),
+    })
+
+    render(<ReservationPage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/login')
+    })
+  })
+
+  it('should display reservation form for authenticated user', async () => {
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    const mockUserData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { user_name: 'テストユーザー' },
+        error: null,
+      }),
+    }
+
+    const mockShopData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'shop-123',
+          shop_name: 'テスト店舗',
+          reservation_hours_start: '10:00:00',
+          reservation_hours_end: '20:00:00',
+        },
+        error: null,
+      }),
+    }
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') return mockUserData
+      if (table === 'shops') return mockShopData
+      return {}
+    })
+
+    render(<ReservationPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reservation-form')).toBeInTheDocument()
+    })
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('users')
+    expect(mockSupabase.from).toHaveBeenCalledWith('shops')
+  })
+
+  it('should redirect to login if user data fetch fails', async () => {
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: null,
+        error: new Error('User not found'),
+      }),
+    })
+
+    render(<ReservationPage />)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/user/login')
+    })
+  })
+
+  it('should display error if shop not found', async () => {
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    const mockUserData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { user_name: 'テストユーザー' },
+        error: null,
+      }),
+    }
+
+    const mockShopData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: null,
+        error: new Error('Shop not found'),
+      }),
+    }
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') return mockUserData
+      if (table === 'shops') return mockShopData
+      return {}
+    })
+
+    render(<ReservationPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('店舗情報が見つかりませんでした')).toBeInTheDocument()
+    })
+  })
+
+  it('should navigate to mypage with reserved=true on success', async () => {
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    const mockUserData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { user_name: 'テストユーザー' },
+        error: null,
+      }),
+    }
+
+    const mockShopData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'shop-123',
+          shop_name: 'テスト店舗',
+          reservation_hours_start: '10:00:00',
+          reservation_hours_end: '20:00:00',
+        },
+        error: null,
+      }),
+    }
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') return mockUserData
+      if (table === 'shops') return mockShopData
+      return {}
+    })
+
+    render(<ReservationPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reservation-form')).toBeInTheDocument()
+    })
+
+    const successButton = screen.getByRole('button', { name: 'Success' })
+    successButton.click()
+
+    expect(mockPush).toHaveBeenCalledWith('/user/mypage?reserved=true')
+  })
+
+  it('should navigate to mypage on cancel', async () => {
+    const mockUser = {
+      id: 'user-123',
+      email: 'test@example.com',
+    }
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    })
+
+    const mockUserData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { user_name: 'テストユーザー' },
+        error: null,
+      }),
+    }
+
+    const mockShopData = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'shop-123',
+          shop_name: 'テスト店舗',
+          reservation_hours_start: '10:00:00',
+          reservation_hours_end: '20:00:00',
+        },
+        error: null,
+      }),
+    }
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') return mockUserData
+      if (table === 'shops') return mockShopData
+      return {}
+    })
+
+    render(<ReservationPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reservation-form')).toBeInTheDocument()
+    })
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+    cancelButton.click()
+
+    expect(mockPush).toHaveBeenCalledWith('/user/mypage')
+  })
+
+  it('should show loading state initially', () => {
+    mockSupabase.auth.getUser.mockImplementation(
+      () => new Promise(() => {}) // Never resolves
+    )
+
+    render(<ReservationPage />)
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+  })
+})

--- a/__tests__/features/reservation/components/ReservationForm.test.tsx
+++ b/__tests__/features/reservation/components/ReservationForm.test.tsx
@@ -1,0 +1,428 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReservationForm } from '@/features/reservation/components/ReservationForm'
+import { useCreateReservation } from '@/features/reservation/hooks/useCreateReservation'
+import { validateReservation } from '@/features/reservation/utils/validateReservation'
+import type { Shop } from '@/features/shop-search/types'
+
+jest.mock('@/features/reservation/hooks/useCreateReservation')
+jest.mock('@/features/reservation/utils/validateReservation')
+
+const mockUseCreateReservation = useCreateReservation as jest.MockedFunction<
+  typeof useCreateReservation
+>
+const mockValidateReservation = validateReservation as jest.MockedFunction<
+  typeof validateReservation
+>
+
+describe('ReservationForm', () => {
+  const mockShop: Shop = {
+    id: 'shop-123',
+    owner_id: 'owner-123',
+    shop_name: 'テスト店舗',
+    business_hours_start: '09:00:00',
+    business_hours_end: '22:00:00',
+    reservation_hours_start: '10:00:00',
+    reservation_hours_end: '20:00:00',
+    business_days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+    closed_days: ['Saturday', 'Sunday'],
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+  }
+
+  const mockCreate = jest.fn()
+  const mockOnSuccess = jest.fn()
+  const mockOnCancel = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseCreateReservation.mockReturnValue({
+      create: mockCreate,
+      isLoading: false,
+      error: null,
+    })
+    mockValidateReservation.mockReturnValue({
+      isValid: true,
+    })
+  })
+
+  it('should render form with all fields', () => {
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.getByLabelText('予約日')).toBeInTheDocument()
+    expect(screen.getByLabelText('予約時刻')).toBeInTheDocument()
+    expect(screen.getByLabelText('予約者名')).toBeInTheDocument()
+    expect(screen.getByLabelText('コメント（任意）')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '予約する' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument()
+  })
+
+  it('should display shop reservation hours', () => {
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.getByText(/受付時間: 10:00-20:00/)).toBeInTheDocument()
+  })
+
+  it('should successfully submit valid reservation', async () => {
+    mockCreate.mockResolvedValue({ success: true })
+
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.type(screen.getByLabelText('予約日'), '2025-12-25')
+    await user.type(screen.getByLabelText('予約時刻'), '14:30')
+    await user.type(screen.getByLabelText('予約者名'), 'テストユーザー')
+    await user.type(screen.getByLabelText('コメント（任意）'), 'よろしくお願いします')
+
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(mockValidateReservation).toHaveBeenCalledWith({
+        reservationDate: '2025-12-25',
+        reservationTime: '14:30',
+        shop: mockShop,
+      })
+    })
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('user-123', 'shop-123', {
+        reservationDate: '2025-12-25',
+        reservationTime: '14:30',
+        reserverName: 'テストユーザー',
+        comment: 'よろしくお願いします',
+      })
+    })
+
+    expect(mockOnSuccess).toHaveBeenCalled()
+  })
+
+  it('should display validation error for empty reservationDate', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.type(screen.getByLabelText('予約時刻'), '14:30')
+    await user.type(screen.getByLabelText('予約者名'), 'テストユーザー')
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('予約日を入力してください')).toBeInTheDocument()
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should display validation error for empty reservationTime', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.type(screen.getByLabelText('予約日'), '2025-12-25')
+    await user.type(screen.getByLabelText('予約者名'), 'テストユーザー')
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('予約時刻を入力してください')).toBeInTheDocument()
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should display validation error for empty reserverName', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.type(screen.getByLabelText('予約日'), '2025-12-25')
+    await user.type(screen.getByLabelText('予約時刻'), '14:30')
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('予約者名を入力してください')).toBeInTheDocument()
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should display validation error for reserverName exceeding 50 characters', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.type(screen.getByLabelText('予約日'), '2025-12-25')
+    await user.type(screen.getByLabelText('予約時刻'), '14:30')
+    await user.type(screen.getByLabelText('予約者名'), 'a'.repeat(51))
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('予約者名は50文字以内で入力してください')
+      ).toBeInTheDocument()
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should display validation error for comment exceeding 500 characters', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const dateInput = screen.getByLabelText('予約日')
+    const timeInput = screen.getByLabelText('予約時刻')
+    const nameInput = screen.getByLabelText('予約者名')
+    const commentInput = screen.getByLabelText('コメント（任意）')
+
+    await user.type(dateInput, '2025-12-25')
+    await user.type(timeInput, '14:30')
+    await user.type(nameInput, 'テストユーザー')
+
+    // Use paste for large text to avoid timeout
+    await user.click(commentInput)
+    await user.paste('a'.repeat(501))
+
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('コメントは500文字以内で入力してください')
+      ).toBeInTheDocument()
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should display business validation error for time outside reservation hours', async () => {
+    mockValidateReservation.mockReturnValue({
+      isValid: false,
+      error: '予約受付時間外です（受付時間: 10:00-20:00）',
+    })
+
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const dateInput = screen.getByLabelText('予約日')
+    const timeInput = screen.getByLabelText('予約時刻')
+    const nameInput = screen.getByLabelText('予約者名')
+
+    await user.type(dateInput, '2025-12-25')
+    await user.type(timeInput, '21:00')
+    await user.type(nameInput, 'テストユーザー')
+
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('予約受付時間外です（受付時間: 10:00-20:00）')
+      ).toBeInTheDocument()
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should display business validation error for past date', async () => {
+    mockValidateReservation.mockReturnValue({
+      isValid: false,
+      error: '過去の日付は予約できません',
+    })
+
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    const dateInput = screen.getByLabelText('予約日')
+    const timeInput = screen.getByLabelText('予約時刻')
+    const nameInput = screen.getByLabelText('予約者名')
+
+    await user.type(dateInput, '2025-12-17')
+    await user.type(timeInput, '14:30')
+    await user.type(nameInput, 'テストユーザー')
+
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('過去の日付は予約できません')).toBeInTheDocument()
+    })
+
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should display error from useCreateReservation hook', async () => {
+    mockUseCreateReservation.mockReturnValue({
+      create: mockCreate,
+      isLoading: false,
+      error: 'この日時は既に予約済みです',
+    })
+
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.getByText('この日時は既に予約済みです')).toBeInTheDocument()
+  })
+
+  it('should call onCancel when cancel button is clicked', async () => {
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+
+    expect(mockOnCancel).toHaveBeenCalled()
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('should disable buttons while loading', async () => {
+    mockUseCreateReservation.mockReturnValue({
+      create: mockCreate,
+      isLoading: true,
+      error: null,
+    })
+
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '予約中...' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'キャンセル' })).toBeDisabled()
+  })
+
+  it('should handle creation failure', async () => {
+    mockCreate.mockResolvedValue({
+      success: false,
+      error: '予約の作成に失敗しました',
+    })
+
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.type(screen.getByLabelText('予約日'), '2025-12-25')
+    await user.type(screen.getByLabelText('予約時刻'), '14:30')
+    await user.type(screen.getByLabelText('予約者名'), 'テストユーザー')
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalled()
+    })
+
+    expect(mockOnSuccess).not.toHaveBeenCalled()
+  })
+
+  it('should allow submitting with empty comment', async () => {
+    mockCreate.mockResolvedValue({ success: true })
+
+    const user = userEvent.setup()
+    render(
+      <ReservationForm
+        userId="user-123"
+        shop={mockShop}
+        onSuccess={mockOnSuccess}
+        onCancel={mockOnCancel}
+      />
+    )
+
+    await user.type(screen.getByLabelText('予約日'), '2025-12-25')
+    await user.type(screen.getByLabelText('予約時刻'), '14:30')
+    await user.type(screen.getByLabelText('予約者名'), 'テストユーザー')
+    await user.click(screen.getByRole('button', { name: '予約する' }))
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('user-123', 'shop-123', {
+        reservationDate: '2025-12-25',
+        reservationTime: '14:30',
+        reserverName: 'テストユーザー',
+        comment: '',
+      })
+    })
+
+    expect(mockOnSuccess).toHaveBeenCalled()
+  })
+})

--- a/__tests__/features/reservation/hooks/useCreateReservation.test.ts
+++ b/__tests__/features/reservation/hooks/useCreateReservation.test.ts
@@ -1,0 +1,215 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useCreateReservation } from '@/features/reservation/hooks/useCreateReservation'
+import { createReservation } from '@/features/reservation/utils/createReservation'
+import type { ReservationFormInput } from '@/features/reservation/types'
+
+jest.mock('@/features/reservation/utils/createReservation')
+
+const mockCreateReservation = createReservation as jest.MockedFunction<
+  typeof createReservation
+>
+
+describe('useCreateReservation', () => {
+  const userId = 'user-123'
+  const shopId = 'shop-456'
+  const formData: ReservationFormInput = {
+    reservationDate: '2025-12-25',
+    reservationTime: '14:30',
+    reserverName: 'テストユーザー',
+    comment: 'よろしくお願いします',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should initialize with correct default state', () => {
+    const { result } = renderHook(() => useCreateReservation())
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(typeof result.current.create).toBe('function')
+  })
+
+  it('should successfully create a reservation', async () => {
+    mockCreateReservation.mockResolvedValue({
+      success: true,
+    })
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    let createResult: { success: boolean; error?: string } | undefined
+
+    await act(async () => {
+      createResult = await result.current.create(userId, shopId, formData)
+    })
+
+    expect(createResult).toEqual({ success: true })
+    expect(mockCreateReservation).toHaveBeenCalledWith(userId, shopId, formData)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('should set loading state during creation', async () => {
+    mockCreateReservation.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ success: true }), 100)
+        )
+    )
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    expect(result.current.isLoading).toBe(false)
+
+    let createPromise: Promise<any>
+    act(() => {
+      createPromise = result.current.create(userId, shopId, formData)
+    })
+
+    // Should be loading immediately after calling create
+    expect(result.current.isLoading).toBe(true)
+
+    await act(async () => {
+      await createPromise
+    })
+
+    // Should not be loading after completion
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('should handle creation failure with error message', async () => {
+    mockCreateReservation.mockResolvedValue({
+      success: false,
+      error: 'この日時は既に予約済みです',
+    })
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    let createResult: { success: boolean; error?: string } | undefined
+
+    await act(async () => {
+      createResult = await result.current.create(userId, shopId, formData)
+    })
+
+    expect(createResult).toEqual({
+      success: false,
+      error: 'この日時は既に予約済みです',
+    })
+    expect(result.current.error).toBe('この日時は既に予約済みです')
+  })
+
+  it('should handle duplicate reservation error', async () => {
+    mockCreateReservation.mockResolvedValue({
+      success: false,
+      error: 'この日時は既に予約済みです',
+    })
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    await act(async () => {
+      await result.current.create(userId, shopId, formData)
+    })
+
+    expect(result.current.error).toBe('この日時は既に予約済みです')
+  })
+
+  it('should handle generic database error', async () => {
+    mockCreateReservation.mockResolvedValue({
+      success: false,
+      error: '予約の作成に失敗しました',
+    })
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    await act(async () => {
+      await result.current.create(userId, shopId, formData)
+    })
+
+    expect(result.current.error).toBe('予約の作成に失敗しました')
+  })
+
+  it('should clear error on successful creation after previous failure', async () => {
+    const { result } = renderHook(() => useCreateReservation())
+
+    // First call fails
+    mockCreateReservation.mockResolvedValueOnce({
+      success: false,
+      error: '予約の作成に失敗しました',
+    })
+
+    await act(async () => {
+      await result.current.create(userId, shopId, formData)
+    })
+
+    expect(result.current.error).toBe('予約の作成に失敗しました')
+
+    // Second call succeeds
+    mockCreateReservation.mockResolvedValueOnce({
+      success: true,
+    })
+
+    await act(async () => {
+      await result.current.create(userId, shopId, formData)
+    })
+
+    expect(result.current.error).toBeNull()
+  })
+
+  it('should allow multiple consecutive calls', async () => {
+    mockCreateReservation.mockResolvedValue({
+      success: true,
+    })
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    await act(async () => {
+      await result.current.create(userId, shopId, formData)
+    })
+
+    await act(async () => {
+      await result.current.create(userId, 'shop-789', formData)
+    })
+
+    expect(mockCreateReservation).toHaveBeenCalledTimes(2)
+    expect(mockCreateReservation).toHaveBeenNthCalledWith(1, userId, shopId, formData)
+    expect(mockCreateReservation).toHaveBeenNthCalledWith(
+      2,
+      userId,
+      'shop-789',
+      formData
+    )
+  })
+
+  it('should handle exception thrown by createReservation', async () => {
+    mockCreateReservation.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    let createResult: { success: boolean; error?: string } | undefined
+
+    await act(async () => {
+      createResult = await result.current.create(userId, shopId, formData)
+    })
+
+    expect(createResult).toEqual({
+      success: false,
+      error: '予約の作成に失敗しました',
+    })
+    expect(result.current.error).toBe('予約の作成に失敗しました')
+  })
+
+  it('should not be loading after error', async () => {
+    mockCreateReservation.mockResolvedValue({
+      success: false,
+      error: '予約の作成に失敗しました',
+    })
+
+    const { result } = renderHook(() => useCreateReservation())
+
+    await act(async () => {
+      await result.current.create(userId, shopId, formData)
+    })
+
+    expect(result.current.isLoading).toBe(false)
+  })
+})

--- a/__tests__/features/reservation/utils/createReservation.test.ts
+++ b/__tests__/features/reservation/utils/createReservation.test.ts
@@ -1,0 +1,214 @@
+import { createReservation } from '@/features/reservation/utils/createReservation'
+import { createClient } from '@/lib/supabase/client'
+import type { ReservationFormInput } from '@/features/reservation/types'
+
+jest.mock('@/lib/supabase/client')
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>
+
+describe('createReservation', () => {
+  const mockSupabase = {
+    from: jest.fn(),
+  }
+
+  const userId = 'user-123'
+  const shopId = 'shop-456'
+  const formData: ReservationFormInput = {
+    reservationDate: '2025-12-25',
+    reservationTime: '14:30',
+    reserverName: 'テストユーザー',
+    comment: 'よろしくお願いします',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCreateClient.mockReturnValue(mockSupabase as any)
+  })
+
+  it('should successfully create a reservation', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: {
+        id: 'reservation-123',
+        user_id: userId,
+        shop_id: shopId,
+        reservation_date: '2025-12-25',
+        reservation_time: '14:30:00',
+        reserver_name: 'テストユーザー',
+        comment: 'よろしくお願いします',
+        status: 'active',
+        created_at: '2025-12-18T00:00:00Z',
+        updated_at: '2025-12-18T00:00:00Z',
+      },
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    const result = await createReservation(userId, shopId, formData)
+
+    expect(result.success).toBe(true)
+    expect(result.error).toBeUndefined()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('reservations')
+    expect(mockInsert).toHaveBeenCalledWith({
+      user_id: userId,
+      shop_id: shopId,
+      reservation_date: '2025-12-25',
+      reservation_time: '14:30:00',
+      reserver_name: 'テストユーザー',
+      comment: 'よろしくお願いします',
+      status: 'active',
+    })
+  })
+
+  it('should convert time from HH:MM to HH:MM:SS format', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    await createReservation(userId, shopId, formData)
+
+    const insertCall = mockInsert.mock.calls[0][0]
+    expect(insertCall.reservation_time).toBe('14:30:00')
+  })
+
+  it('should handle empty comment with default value', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    const dataWithoutComment: ReservationFormInput = {
+      ...formData,
+      comment: '',
+    }
+
+    await createReservation(userId, shopId, dataWithoutComment)
+
+    const insertCall = mockInsert.mock.calls[0][0]
+    expect(insertCall.comment).toBe('')
+  })
+
+  it('should detect duplicate reservation (UNIQUE constraint violation)', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: null,
+      error: {
+        code: '23505',
+        message: 'duplicate key value violates unique constraint',
+      },
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    const result = await createReservation(userId, shopId, formData)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('この日時は既に予約済みです')
+  })
+
+  it('should handle generic database errors', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: null,
+      error: {
+        code: '42P01',
+        message: 'relation "reservations" does not exist',
+      },
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    const result = await createReservation(userId, shopId, formData)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('予約の作成に失敗しました')
+  })
+
+  it('should handle network errors', async () => {
+    const mockInsert = jest.fn().mockRejectedValue(new Error('Network error'))
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    const result = await createReservation(userId, shopId, formData)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('予約の作成に失敗しました')
+  })
+
+  it('should set status to active by default', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    await createReservation(userId, shopId, formData)
+
+    const insertCall = mockInsert.mock.calls[0][0]
+    expect(insertCall.status).toBe('active')
+  })
+
+  it('should handle special characters in reserver name', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    const specialData: ReservationFormInput = {
+      ...formData,
+      reserverName: '山田 太郎（やまだ たろう）',
+    }
+
+    const result = await createReservation(userId, shopId, specialData)
+
+    expect(result.success).toBe(true)
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reserver_name: '山田 太郎（やまだ たろう）',
+      })
+    )
+  })
+
+  it('should handle maximum length comment (500 characters)', async () => {
+    const mockInsert = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    })
+
+    mockSupabase.from.mockReturnValue({
+      insert: mockInsert,
+    } as any)
+
+    const longCommentData: ReservationFormInput = {
+      ...formData,
+      comment: 'a'.repeat(500),
+    }
+
+    const result = await createReservation(userId, shopId, longCommentData)
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/__tests__/features/reservation/utils/validateReservation.test.ts
+++ b/__tests__/features/reservation/utils/validateReservation.test.ts
@@ -1,0 +1,178 @@
+import { validateReservation } from '@/features/reservation/utils/validateReservation'
+import type { Shop } from '@/features/shop-search/types'
+
+describe('validateReservation', () => {
+  const mockShop: Shop = {
+    id: 'shop-123',
+    owner_id: 'owner-123',
+    shop_name: 'テスト店舗',
+    business_hours_start: '09:00:00',
+    business_hours_end: '22:00:00',
+    reservation_hours_start: '10:00:00',
+    reservation_hours_end: '20:00:00',
+    business_days: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+    closed_days: ['Saturday', 'Sunday'],
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+  }
+
+  describe('Valid reservations', () => {
+    it('should accept reservation within valid time range', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '15:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept reservation at start time', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '10:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept reservation at end time', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '20:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeUndefined()
+    })
+  })
+
+  describe('Invalid time range', () => {
+    it('should reject reservation before opening hours', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '09:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe('予約受付時間外です（受付時間: 10:00-20:00）')
+    })
+
+    it('should reject reservation after closing hours', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '21:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe('予約受付時間外です（受付時間: 10:00-20:00）')
+    })
+
+    it('should reject reservation just before opening', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '09:59',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe('予約受付時間外です（受付時間: 10:00-20:00）')
+    })
+
+    it('should reject reservation just after closing', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '20:01',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe('予約受付時間外です（受付時間: 10:00-20:00）')
+    })
+  })
+
+  describe('Past date validation', () => {
+    beforeEach(() => {
+      // Mock current date to 2025-12-18
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2025-12-18T12:00:00Z'))
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should reject past date', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-17',
+        reservationTime: '15:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(false)
+      expect(result.error).toBe('過去の日付は予約できません')
+    })
+
+    it('should accept today\'s date', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-18',
+        reservationTime: '15:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('should accept future date', () => {
+      const result = validateReservation({
+        reservationDate: '2025-12-19',
+        reservationTime: '15:00',
+        shop: mockShop,
+      })
+
+      expect(result.isValid).toBe(true)
+      expect(result.error).toBeUndefined()
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle shop with 24-hour format times', () => {
+      const shop24h: Shop = {
+        ...mockShop,
+        reservation_hours_start: '00:00:00',
+        reservation_hours_end: '23:59:00',
+      }
+
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '23:30',
+        shop: shop24h,
+      })
+
+      expect(result.isValid).toBe(true)
+    })
+
+    it('should handle shop with HH:MM format (without seconds)', () => {
+      const shopHHMM: Shop = {
+        ...mockShop,
+        reservation_hours_start: '10:00',
+        reservation_hours_end: '20:00',
+      }
+
+      const result = validateReservation({
+        reservationDate: '2025-12-25',
+        reservationTime: '15:00',
+        shop: shopHHMM,
+      })
+
+      expect(result.isValid).toBe(true)
+    })
+  })
+})

--- a/__tests__/features/reservation/utils/validation.test.ts
+++ b/__tests__/features/reservation/utils/validation.test.ts
@@ -1,0 +1,167 @@
+import { reservationSchema } from '@/features/reservation/utils/validation'
+
+describe('reservationSchema', () => {
+  it('should validate correct reservation data', () => {
+    const validData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: 'テストユーザー',
+      comment: 'よろしくお願いします',
+    }
+
+    const result = reservationSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual(validData)
+    }
+  })
+
+  it('should accept empty comment with default value', () => {
+    const dataWithoutComment = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: 'テストユーザー',
+    }
+
+    const result = reservationSchema.safeParse(dataWithoutComment)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.comment).toBe('')
+    }
+  })
+
+  it('should reject invalid date format', () => {
+    const invalidData = {
+      reservationDate: '2025/12/25', // Wrong format
+      reservationTime: '14:30',
+      reserverName: 'テストユーザー',
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject invalid time format', () => {
+    const invalidData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30:00', // Should be HH:MM, not HH:MM:SS
+      reserverName: 'テストユーザー',
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject empty reservationDate', () => {
+    const invalidData = {
+      reservationDate: '',
+      reservationTime: '14:30',
+      reserverName: 'テストユーザー',
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject empty reservationTime', () => {
+    const invalidData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '',
+      reserverName: 'テストユーザー',
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject empty reserverName', () => {
+    const invalidData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: '',
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject reserverName with only whitespace', () => {
+    const invalidData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: '   ',
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject reserverName exceeding 50 characters', () => {
+    const invalidData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: 'a'.repeat(51),
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should accept reserverName at exactly 50 characters', () => {
+    const validData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: 'a'.repeat(50),
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject comment exceeding 500 characters', () => {
+    const invalidData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: 'テストユーザー',
+      comment: 'a'.repeat(501),
+    }
+
+    const result = reservationSchema.safeParse(invalidData)
+    expect(result.success).toBe(false)
+  })
+
+  it('should accept comment at exactly 500 characters', () => {
+    const validData = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: 'テストユーザー',
+      comment: 'a'.repeat(500),
+    }
+
+    const result = reservationSchema.safeParse(validData)
+    expect(result.success).toBe(true)
+  })
+
+  it('should trim reserverName whitespace', () => {
+    const dataWithWhitespace = {
+      reservationDate: '2025-12-25',
+      reservationTime: '14:30',
+      reserverName: '  テストユーザー  ',
+      comment: '',
+    }
+
+    const result = reservationSchema.safeParse(dataWithWhitespace)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.reserverName).toBe('テストユーザー')
+    }
+  })
+})

--- a/app/user/mypage/page.tsx
+++ b/app/user/mypage/page.tsx
@@ -24,6 +24,7 @@ export default function MyPage() {
     time?: string
   }>({})
   const [showSuccessMessage, setShowSuccessMessage] = useState(false)
+  const [successMessageType, setSuccessMessageType] = useState<'updated' | 'reserved' | null>(null)
 
   useEffect(() => {
     const init = async () => {
@@ -61,9 +62,21 @@ export default function MyPage() {
   useEffect(() => {
     if (searchParams.get('updated') === 'true') {
       setShowSuccessMessage(true)
+      setSuccessMessageType('updated')
       // Auto-dismiss after 3 seconds
       const timer = setTimeout(() => {
         setShowSuccessMessage(false)
+        setSuccessMessageType(null)
+      }, 3000)
+      return () => clearTimeout(timer)
+    }
+    if (searchParams.get('reserved') === 'true') {
+      setShowSuccessMessage(true)
+      setSuccessMessageType('reserved')
+      // Auto-dismiss after 3 seconds
+      const timer = setTimeout(() => {
+        setShowSuccessMessage(false)
+        setSuccessMessageType(null)
       }, 3000)
       return () => clearTimeout(timer)
     }
@@ -117,7 +130,9 @@ export default function MyPage() {
               className="mb-4 p-4 bg-green-50 border border-green-200 text-green-800 rounded-md"
               role="alert"
             >
-              ユーザー情報を更新しました
+              {successMessageType === 'reserved'
+                ? '予約が完了しました'
+                : 'ユーザー情報を更新しました'}
             </div>
           )}
 

--- a/app/user/reservation/[shopId]/page.tsx
+++ b/app/user/reservation/[shopId]/page.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import { ReservationForm } from '@/features/reservation/components/ReservationForm'
+import type { Shop } from '@/features/shop-search/types'
+
+/**
+ * Reservation Page
+ *
+ * Allows authenticated users to make a reservation at a shop
+ *
+ * Flow:
+ * 1. Get shopId from URL params
+ * 2. Check authentication (redirect to /user/login if not authenticated)
+ * 3. Fetch user data
+ * 4. Fetch shop data
+ * 5. Display ReservationForm
+ * 6. On success: redirect to /user/mypage?reserved=true
+ * 7. On cancel: redirect to /user/mypage
+ */
+export default function ReservationPage() {
+  const router = useRouter()
+  const params = useParams()
+  const shopId = params.shopId as string
+
+  const [userId, setUserId] = useState<string | null>(null)
+  const [shop, setShop] = useState<Shop | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function init() {
+      try {
+        const supabase = createClient()
+
+        // Check authentication
+        const {
+          data: { user },
+          error: authError,
+        } = await supabase.auth.getUser()
+
+        if (authError || !user) {
+          router.push('/user/login')
+          return
+        }
+
+        // Fetch user data
+        const { data: userData, error: userError } = await supabase
+          .from('users')
+          .select('user_name')
+          .eq('id', user.id)
+          .single()
+
+        if (userError || !userData) {
+          router.push('/user/login')
+          return
+        }
+
+        // Fetch shop data
+        const { data: shopData, error: shopError } = await supabase
+          .from('shops')
+          .select('*')
+          .eq('id', shopId)
+          .single()
+
+        if (shopError || !shopData) {
+          setError('店舗情報が見つかりませんでした')
+          setLoading(false)
+          return
+        }
+
+        setUserId(user.id)
+        setShop(shopData)
+        setLoading(false)
+      } catch (err) {
+        console.error('Initialization error:', err)
+        setError('エラーが発生しました')
+        setLoading(false)
+      }
+    }
+
+    init()
+  }, [router, shopId])
+
+  const handleSuccess = () => {
+    router.push('/user/mypage?reserved=true')
+  }
+
+  const handleCancel = () => {
+    router.push('/user/mypage')
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-600">読み込み中...</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-red-600 mb-4">{error}</p>
+          <button
+            onClick={() => router.push('/user/mypage')}
+            className="bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700"
+          >
+            マイページに戻る
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!userId || !shop) {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <ReservationForm
+        userId={userId}
+        shop={shop}
+        onSuccess={handleSuccess}
+        onCancel={handleCancel}
+      />
+    </div>
+  )
+}

--- a/features/reservation/components/ReservationForm.tsx
+++ b/features/reservation/components/ReservationForm.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { reservationSchema } from '@/features/reservation/utils/validation'
+import { useCreateReservation } from '@/features/reservation/hooks/useCreateReservation'
+import { validateReservation } from '@/features/reservation/utils/validateReservation'
+import type { ReservationFormInput } from '@/features/reservation/types'
+import type { Shop } from '@/features/shop-search/types'
+
+interface ReservationFormProps {
+  userId: string
+  shop: Shop
+  onSuccess: () => void
+  onCancel: () => void
+}
+
+/**
+ * Reservation form component
+ *
+ * Allows users to create a reservation with:
+ * - Reservation date (date input)
+ * - Reservation time (time input)
+ * - Reserver name (text input, max 50 chars)
+ * - Comment (textarea, max 500 chars, optional)
+ *
+ * Validates input with Zod schema and business rules before submitting
+ */
+export function ReservationForm({
+  userId,
+  shop,
+  onSuccess,
+  onCancel,
+}: ReservationFormProps) {
+  const [businessError, setBusinessError] = useState<string | null>(null)
+  const { create, isLoading, error: hookError } = useCreateReservation()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ReservationFormInput>({
+    resolver: zodResolver(reservationSchema),
+    defaultValues: {
+      reservationDate: '',
+      reservationTime: '',
+      reserverName: '',
+      comment: '',
+    },
+  })
+
+  const onSubmit = async (data: ReservationFormInput) => {
+    // Clear previous business validation error
+    setBusinessError(null)
+
+    // Validate business rules (time range, past date)
+    const validation = validateReservation({
+      reservationDate: data.reservationDate,
+      reservationTime: data.reservationTime,
+      shop,
+    })
+
+    if (!validation.isValid) {
+      setBusinessError(validation.error || null)
+      return
+    }
+
+    // Create reservation
+    const result = await create(userId, shop.id, data)
+
+    if (result.success) {
+      onSuccess()
+    }
+  }
+
+  // Format reservation hours for display (remove seconds)
+  const reservationHoursStart = shop.reservation_hours_start.substring(0, 5)
+  const reservationHoursEnd = shop.reservation_hours_end.substring(0, 5)
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h2 className="text-2xl font-bold mb-2">{shop.shop_name}</h2>
+        <p className="text-gray-600 mb-6">
+          受付時間: {reservationHoursStart}-{reservationHoursEnd}
+        </p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {/* Reservation Date */}
+          <div>
+            <label htmlFor="reservationDate" className="block text-sm font-medium mb-1">
+              予約日
+            </label>
+            <input
+              id="reservationDate"
+              type="date"
+              {...register('reservationDate')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.reservationDate && (
+              <p className="text-red-600 text-sm mt-1">
+                {errors.reservationDate.message}
+              </p>
+            )}
+          </div>
+
+          {/* Reservation Time */}
+          <div>
+            <label htmlFor="reservationTime" className="block text-sm font-medium mb-1">
+              予約時刻
+            </label>
+            <input
+              id="reservationTime"
+              type="time"
+              {...register('reservationTime')}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.reservationTime && (
+              <p className="text-red-600 text-sm mt-1">
+                {errors.reservationTime.message}
+              </p>
+            )}
+          </div>
+
+          {/* Reserver Name */}
+          <div>
+            <label htmlFor="reserverName" className="block text-sm font-medium mb-1">
+              予約者名
+            </label>
+            <input
+              id="reserverName"
+              type="text"
+              {...register('reserverName')}
+              placeholder="店舗で使用する名前"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.reserverName && (
+              <p className="text-red-600 text-sm mt-1">
+                {errors.reserverName.message}
+              </p>
+            )}
+          </div>
+
+          {/* Comment */}
+          <div>
+            <label htmlFor="comment" className="block text-sm font-medium mb-1">
+              コメント（任意）
+            </label>
+            <textarea
+              id="comment"
+              {...register('comment')}
+              placeholder="店舗へのメッセージ（500文字まで）"
+              rows={4}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.comment && (
+              <p className="text-red-600 text-sm mt-1">{errors.comment.message}</p>
+            )}
+          </div>
+
+          {/* Business Validation Error */}
+          {businessError && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              {businessError}
+            </div>
+          )}
+
+          {/* Hook Error */}
+          {hookError && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              {hookError}
+            </div>
+          )}
+
+          {/* Buttons */}
+          <div className="flex gap-4 pt-4">
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {isLoading ? '予約中...' : '予約する'}
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isLoading}
+              className="flex-1 bg-gray-200 text-gray-800 py-2 px-4 rounded-md hover:bg-gray-300 disabled:bg-gray-100 disabled:cursor-not-allowed"
+            >
+              キャンセル
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/features/reservation/hooks/useCreateReservation.ts
+++ b/features/reservation/hooks/useCreateReservation.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { createReservation } from '@/features/reservation/utils/createReservation'
+import type {
+  ReservationFormInput,
+  CreateReservationResult,
+} from '@/features/reservation/types'
+
+/**
+ * Custom hook for managing reservation creation state
+ *
+ * Provides:
+ * - isLoading: Boolean indicating if creation is in progress
+ * - error: Error message from failed creation (null if no error)
+ * - create: Function to create a reservation
+ *
+ * @returns Hook state and functions
+ */
+export function useCreateReservation() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  /**
+   * Creates a new reservation
+   *
+   * @param userId - User ID from authenticated session
+   * @param shopId - Shop ID from URL parameter
+   * @param data - Reservation form data
+   * @returns CreateReservationResult with success status and optional error
+   */
+  const create = async (
+    userId: string,
+    shopId: string,
+    data: ReservationFormInput
+  ): Promise<CreateReservationResult> => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const result = await createReservation(userId, shopId, data)
+
+      if (!result.success && result.error) {
+        setError(result.error)
+      }
+
+      return result
+    } catch (err) {
+      const errorMessage = '予約の作成に失敗しました'
+      setError(errorMessage)
+      return {
+        success: false,
+        error: errorMessage,
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return {
+    isLoading,
+    error,
+    create,
+  }
+}

--- a/features/reservation/types/index.ts
+++ b/features/reservation/types/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Reservation Type Definitions
+ *
+ * These types represent the reservation system data structures
+ * aligned with the database schema defined in migration_create_reservations_tables.sql
+ */
+
+/**
+ * Database schema for reservations and past_reservations tables
+ */
+export interface Reservation {
+  id: string
+  user_id: string
+  shop_id: string
+  reservation_date: string // ISO date format (YYYY-MM-DD)
+  reservation_time: string // HH:MM:SS format
+  reserver_name: string // Name to be used at the shop (can be pseudonym)
+  comment: string // Message to shop staff (max 500 characters)
+  status: 'active' | 'cancelled' | 'completed'
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Form input type for reservation creation
+ * Used by react-hook-form in ReservationForm component
+ */
+export interface ReservationFormInput {
+  reservationDate: string // YYYY-MM-DD format from HTML date input
+  reservationTime: string // HH:MM format from HTML time input
+  reserverName: string
+  comment: string
+}
+
+/**
+ * Result type for reservation creation operation
+ */
+export interface CreateReservationResult {
+  success: boolean
+  error?: string
+}

--- a/features/reservation/utils/createReservation.ts
+++ b/features/reservation/utils/createReservation.ts
@@ -1,0 +1,71 @@
+import { createClient } from '@/lib/supabase/client'
+import type {
+  ReservationFormInput,
+  CreateReservationResult,
+} from '@/features/reservation/types'
+
+/**
+ * Creates a new reservation in the database
+ *
+ * Converts time from HH:MM (HTML input format) to HH:MM:SS (PostgreSQL time format)
+ * and inserts the reservation into the reservations table.
+ *
+ * @param userId - User ID from authenticated session
+ * @param shopId - Shop ID from URL parameter
+ * @param data - Reservation form data
+ * @returns CreateReservationResult with success status and optional error message
+ */
+export async function createReservation(
+  userId: string,
+  shopId: string,
+  data: ReservationFormInput
+): Promise<CreateReservationResult> {
+  try {
+    const supabase = createClient()
+
+    // Convert time from HH:MM to HH:MM:SS for PostgreSQL time type
+    const reservationTimeWithSeconds = `${data.reservationTime}:00`
+
+    // Insert reservation into database
+    const { data: reservationData, error } = await supabase
+      .from('reservations')
+      .insert({
+        user_id: userId,
+        shop_id: shopId,
+        reservation_date: data.reservationDate,
+        reservation_time: reservationTimeWithSeconds,
+        reserver_name: data.reserverName,
+        comment: data.comment,
+        status: 'active',
+      })
+
+    // Handle database errors
+    if (error) {
+      // Check for UNIQUE constraint violation (duplicate reservation)
+      if (error.code === '23505') {
+        return {
+          success: false,
+          error: 'この日時は既に予約済みです',
+        }
+      }
+
+      // Generic database error
+      console.error('Reservation creation error:', error)
+      return {
+        success: false,
+        error: '予約の作成に失敗しました',
+      }
+    }
+
+    return {
+      success: true,
+    }
+  } catch (error) {
+    // Handle unexpected errors (network, etc.)
+    console.error('Unexpected error during reservation creation:', error)
+    return {
+      success: false,
+      error: '予約の作成に失敗しました',
+    }
+  }
+}

--- a/features/reservation/utils/validateReservation.ts
+++ b/features/reservation/utils/validateReservation.ts
@@ -1,0 +1,75 @@
+import type { Shop } from '@/features/shop-search/types'
+
+/**
+ * Validation result interface
+ */
+export interface ValidationResult {
+  isValid: boolean
+  error?: string
+}
+
+/**
+ * Parameters for validateReservation function
+ */
+export interface ValidateReservationParams {
+  reservationDate: string // YYYY-MM-DD
+  reservationTime: string // HH:MM
+  shop: Shop
+}
+
+/**
+ * Validates reservation business rules:
+ * 1. Reservation time must be within shop's reservation hours
+ * 2. Reservation date must not be in the past
+ *
+ * @param params - Validation parameters
+ * @returns Validation result with error message if invalid
+ */
+export function validateReservation(params: ValidateReservationParams): ValidationResult {
+  const { reservationDate, reservationTime, shop } = params
+
+  // Check if reservation date is not in the past
+  const today = new Date()
+  today.setHours(0, 0, 0, 0) // Reset time to compare dates only
+
+  const reservationDateObj = new Date(reservationDate)
+  reservationDateObj.setHours(0, 0, 0, 0)
+
+  if (reservationDateObj < today) {
+    return {
+      isValid: false,
+      error: '過去の日付は予約できません',
+    }
+  }
+
+  // Check if reservation time is within shop's reservation hours
+  const reservationTimeMinutes = timeToMinutes(reservationTime)
+  const startTimeMinutes = timeToMinutes(shop.reservation_hours_start)
+  const endTimeMinutes = timeToMinutes(shop.reservation_hours_end)
+
+  if (reservationTimeMinutes < startTimeMinutes || reservationTimeMinutes > endTimeMinutes) {
+    // Format times for display (remove seconds if present)
+    const startTimeDisplay = shop.reservation_hours_start.substring(0, 5)
+    const endTimeDisplay = shop.reservation_hours_end.substring(0, 5)
+
+    return {
+      isValid: false,
+      error: `予約受付時間外です（受付時間: ${startTimeDisplay}-${endTimeDisplay}）`,
+    }
+  }
+
+  return {
+    isValid: true,
+  }
+}
+
+/**
+ * Converts time string (HH:MM or HH:MM:SS) to minutes since midnight
+ *
+ * @param time - Time string in HH:MM or HH:MM:SS format
+ * @returns Minutes since midnight
+ */
+function timeToMinutes(time: string): number {
+  const [hours, minutes] = time.split(':').map(Number)
+  return hours * 60 + minutes
+}

--- a/features/reservation/utils/validation.ts
+++ b/features/reservation/utils/validation.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+/**
+ * Zod validation schema for reservation form input
+ *
+ * Validates:
+ * - reservationDate: YYYY-MM-DD format (HTML date input)
+ * - reservationTime: HH:MM format (HTML time input)
+ * - reserverName: 1-50 characters, trimmed, no whitespace-only
+ * - comment: max 500 characters, optional with default empty string
+ */
+export const reservationSchema = z.object({
+  reservationDate: z
+    .string()
+    .min(1, '予約日を入力してください')
+    .regex(/^\d{4}-\d{2}-\d{2}$/, '予約日の形式が正しくありません'),
+
+  reservationTime: z
+    .string()
+    .min(1, '予約時刻を入力してください')
+    .regex(/^\d{2}:\d{2}$/, '予約時刻の形式が正しくありません'),
+
+  reserverName: z
+    .string()
+    .trim()
+    .min(1, '予約者名を入力してください')
+    .max(50, '予約者名は50文字以内で入力してください'),
+
+  comment: z
+    .string()
+    .max(500, 'コメントは500文字以内で入力してください')
+    .optional()
+    .default(''),
+})
+
+/**
+ * TypeScript type inferred from the Zod schema
+ */
+export type ReservationSchemaType = z.infer<typeof reservationSchema>

--- a/features/shop-search/components/SearchResults.tsx
+++ b/features/shop-search/components/SearchResults.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import type { Shop } from '../types'
 
@@ -16,6 +17,7 @@ export function SearchResults({
   totalPages,
   onPageChange,
 }: SearchResultsProps) {
+  const router = useRouter()
   if (results.length === 0) {
     return (
       <div className="bg-white rounded-lg shadow p-6">
@@ -53,7 +55,7 @@ export function SearchResults({
               <Button
                 variant="default"
                 className="bg-blue-600 hover:bg-blue-700"
-                disabled
+                onClick={() => router.push(`/user/reservation/${shop.id}`)}
               >
                 予約
               </Button>

--- a/supabase/migrations/20251219070312_create_reservations_tables.sql
+++ b/supabase/migrations/20251219070312_create_reservations_tables.sql
@@ -1,0 +1,90 @@
+-- Migration: Create reservations and past_reservations tables
+-- Created: 2025-12-18
+-- Purpose: Implement reservation system with scalability consideration
+--          - reservations: Current reservations (within 2 weeks)
+--          - past_reservations: Archive for old reservations (older than 2 weeks)
+--          - Both tables have identical schema for easy data migration in the future
+
+-- ============================================================================
+-- RESERVATIONS TABLE (Current Reservations)
+-- ============================================================================
+
+CREATE TABLE reservations (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  shop_id uuid REFERENCES shops(id) ON DELETE CASCADE NOT NULL,
+  reservation_date date NOT NULL,
+  reservation_time time NOT NULL,
+  reserver_name text NOT NULL,
+  comment text CHECK (length(comment) <= 500),
+  status text NOT NULL CHECK (status IN ('active', 'cancelled', 'completed')) DEFAULT 'active',
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL,
+
+  -- Prevent duplicate reservations
+  CONSTRAINT unique_reservation UNIQUE (user_id, shop_id, reservation_date, reservation_time)
+);
+
+-- Indexes for performance
+CREATE INDEX idx_reservations_user_id ON reservations(user_id);
+CREATE INDEX idx_reservations_shop_id ON reservations(shop_id);
+CREATE INDEX idx_reservations_date ON reservations(reservation_date);
+CREATE INDEX idx_reservations_status ON reservations(status);
+
+-- Trigger for automatic updated_at update
+CREATE TRIGGER update_reservations_updated_at
+  BEFORE UPDATE ON reservations
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- PAST_RESERVATIONS TABLE (Archive)
+-- ============================================================================
+
+-- IMPORTANT: This table has IDENTICAL schema to reservations table
+-- This design allows future data migration using simple SQL:
+--   INSERT INTO past_reservations SELECT * FROM reservations WHERE ...
+-- Migration logic is NOT implemented in this issue.
+
+CREATE TABLE past_reservations (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  shop_id uuid REFERENCES shops(id) ON DELETE CASCADE NOT NULL,
+  reservation_date date NOT NULL,
+  reservation_time time NOT NULL,
+  reserver_name text NOT NULL,
+  comment text CHECK (length(comment) <= 500),
+  status text NOT NULL CHECK (status IN ('active', 'cancelled', 'completed')) DEFAULT 'active',
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL,
+
+  -- Prevent duplicate reservations (same constraint as reservations table)
+  CONSTRAINT unique_past_reservation UNIQUE (user_id, shop_id, reservation_date, reservation_time)
+);
+
+-- Indexes for performance (same as reservations table)
+CREATE INDEX idx_past_reservations_user_id ON past_reservations(user_id);
+CREATE INDEX idx_past_reservations_shop_id ON past_reservations(shop_id);
+CREATE INDEX idx_past_reservations_date ON past_reservations(reservation_date);
+CREATE INDEX idx_past_reservations_status ON past_reservations(status);
+
+-- Trigger for automatic updated_at update (same as reservations table)
+CREATE TRIGGER update_past_reservations_updated_at
+  BEFORE UPDATE ON past_reservations
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- COMMENTS
+-- ============================================================================
+
+COMMENT ON TABLE reservations IS 'Current reservations within 2 weeks from current date';
+COMMENT ON TABLE past_reservations IS 'Archive for reservations older than 2 weeks. Identical schema to reservations table for easy data migration.';
+
+COMMENT ON COLUMN reservations.reserver_name IS 'Name used at the shop. Can be different from user_name to allow pseudonyms.';
+COMMENT ON COLUMN reservations.comment IS 'Message to shop staff. Max 500 characters.';
+COMMENT ON COLUMN reservations.status IS 'Reservation status: active, cancelled, or completed';
+
+COMMENT ON COLUMN past_reservations.reserver_name IS 'Name used at the shop. Can be different from user_name to allow pseudonyms.';
+COMMENT ON COLUMN past_reservations.comment IS 'Message to shop staff. Max 500 characters.';
+COMMENT ON COLUMN past_reservations.status IS 'Reservation status: active, cancelled, or completed';


### PR DESCRIPTION
ユーザーが店舗検索結果から予約を作成できる機能を実装しました。

主な変更点:
- データベース: reservationsとpast_reservationsテーブルを作成（肥大化対策）
- バリデーション: Zodスキーマとビジネスルール検証を実装
- ビジネスロジック: 予約作成、重複チェック、時刻フォーマット変換
- UI: 予約フォームと予約ページを実装
- 既存機能修正: 予約ボタン有効化、成功メッセージ分岐

テスト: 66テスト実装（全てパス）
- validation.ts: 13テスト
- validateReservation.ts: 12テスト
- createReservation.ts: 9テスト
- useCreateReservation.ts: 10テスト
- ReservationForm.tsx: 15テスト
- ReservationPage: 7テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)