### PR TITLE
fix: RLSポリシー対応のクエリ修正とマイグレーション追加 (Issue #27)

### DIFF
--- a/supabase/migrations/20251221064215_add_reservations_rls_policies.sql
+++ b/supabase/migrations/20251221064215_add_reservations_rls_policies.sql
@@ -1,0 +1,69 @@
+-- Migration: Add RLS policies for reservations table
+-- Created: 2025-12-21
+-- Purpose: Allow shop owners to view reservations for their shops
+
+-- Enable RLS on reservations table
+ALTER TABLE reservations ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view their own reservations
+CREATE POLICY "Users can view their own reservations"
+  ON reservations
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Policy: Shop owners can view reservations for their shops
+CREATE POLICY "Shop owners can view reservations for their shops"
+  ON reservations
+  FOR SELECT
+  USING (
+    shop_id IN (
+      SELECT id FROM shops WHERE owner_id = auth.uid()
+    )
+  );
+
+-- Policy: Users can insert their own reservations
+CREATE POLICY "Users can insert their own reservations"
+  ON reservations
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Users can update their own reservations
+CREATE POLICY "Users can update their own reservations"
+  ON reservations
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Policy: Shop owners can update reservations for their shops (e.g., mark as completed)
+CREATE POLICY "Shop owners can update reservations for their shops"
+  ON reservations
+  FOR UPDATE
+  USING (
+    shop_id IN (
+      SELECT id FROM shops WHERE owner_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    shop_id IN (
+      SELECT id FROM shops WHERE owner_id = auth.uid()
+    )
+  );
+
+-- Enable RLS on past_reservations table (same policies as reservations)
+ALTER TABLE past_reservations ENABLE ROW LEVEL SECURITY;
+
+-- Policy: Users can view their own past reservations
+CREATE POLICY "Users can view their own past reservations"
+  ON past_reservations
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Policy: Shop owners can view past reservations for their shops
+CREATE POLICY "Shop owners can view past reservations for their shops"
+  ON past_reservations
+  FOR SELECT
+  USING (
+    shop_id IN (
+      SELECT id FROM shops WHERE owner_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
店舗管理者が自店舗の予約一覧を正常に取得できるように、
RLSポリシーを考慮したクエリに修正しました。

主な変更:
- fetchShopReservations: shopsテーブル経由で予約を取得
- RLSポリシーのマイグレーションファイルを追加
- デバッグログを削除してクリーンなコードに修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)