### PR TITLE
fix: 店舗管理者ページにロールチェックを追加 (Issue #32)

### DIFF
--- a/app/shop-admin/reservations/page.tsx
+++ b/app/shop-admin/reservations/page.tsx
@@ -43,16 +43,23 @@ function ReservationsPageContent() {
         return
       }
 
-      // Fetch user name
+      // Fetch user name and role
       const { data: userData, error: userError } = await supabase
         .from('users')
-        .select('user_name')
+        .select('user_name, role')
         .eq('id', user.id)
         .single()
 
       if (userError || !userData) {
         console.error('Failed to fetch user data:', userError)
         router.push('/shop-admin/login')
+        return
+      }
+
+      // Check if user is shop_manager
+      if (userData.role !== 'shop_manager') {
+        console.warn('Access denied: User is not a shop manager')
+        router.push('/user/login')
         return
       }
 

--- a/app/shop-admin/shop-settings/page.tsx
+++ b/app/shop-admin/shop-settings/page.tsx
@@ -22,6 +22,26 @@ export default function ShopSettingsPage() {
         return
       }
 
+      // ロールチェック
+      const { data: userData, error: userError } = await supabase
+        .from('users')
+        .select('role')
+        .eq('id', user.id)
+        .single()
+
+      if (userError || !userData) {
+        console.error('Failed to fetch user data:', userError)
+        router.push('/shop-admin/login')
+        return
+      }
+
+      // Check if user is shop_manager
+      if (userData.role !== 'shop_manager') {
+        console.warn('Access denied: User is not a shop manager')
+        router.push('/user/login')
+        return
+      }
+
       setUserId(user.id)
       setIsLoading(false)
     }


### PR DESCRIPTION
一般ユーザーが店舗管理者ページにアクセスできてしまう問題を修正。

変更内容:
- app/shop-admin/reservations/page.tsx: roleチェック追加
- app/shop-admin/shop-settings/page.tsx: roleチェック追加
- role !== 'shop_manager' の場合、/user/login へリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)