### PR TITLE
feat: システム管理者アカウント登録・ログイン画面を実装 (Issue #34)

### DIFF
--- a/__tests__/features/auth/components/SystemAdminLoginForm.test.tsx
+++ b/__tests__/features/auth/components/SystemAdminLoginForm.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SystemAdminLoginForm } from '@/features/auth/components/SystemAdminLoginForm'
+
+describe('SystemAdminLoginForm', () => {
+  it('renders all form fields', () => {
+    render(<SystemAdminLoginForm onSuccess={() => {}} />)
+
+    expect(screen.getByLabelText(/ユーザー名またはメールアドレス/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/パスワード/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /ログイン/i })).toBeInTheDocument()
+  })
+
+  it('shows validation errors for empty fields', async () => {
+    const user = userEvent.setup()
+    render(<SystemAdminLoginForm onSuccess={() => {}} />)
+
+    const submitButton = screen.getByRole('button', { name: /ログイン/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/ユーザー名を入力してください/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders submit button', () => {
+    render(<SystemAdminLoginForm onSuccess={() => {}} />)
+
+    const submitButton = screen.getByRole('button', { name: /ログイン/i })
+    expect(submitButton).toBeInTheDocument()
+    expect(submitButton).not.toBeDisabled()
+  })
+})

--- a/__tests__/features/auth/components/SystemAdminSignUpForm.test.tsx
+++ b/__tests__/features/auth/components/SystemAdminSignUpForm.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SystemAdminSignUpForm } from '@/features/auth/components/SystemAdminSignUpForm'
+
+describe('SystemAdminSignUpForm', () => {
+  it('renders all form fields', () => {
+    render(<SystemAdminSignUpForm onSuccess={() => {}} />)
+
+    expect(screen.getByLabelText(/ユーザー名/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/メールアドレス/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/パスワード/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /登録/i })).toBeInTheDocument()
+  })
+
+  it('shows validation errors for empty fields', async () => {
+    const user = userEvent.setup()
+    render(<SystemAdminSignUpForm onSuccess={() => {}} />)
+
+    const submitButton = screen.getByRole('button', { name: /登録/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/ユーザー名は3文字以上/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows link to login page if callback provided', () => {
+    const mockSwitchToLogin = jest.fn()
+    render(<SystemAdminSignUpForm onSuccess={() => {}} onSwitchToLogin={mockSwitchToLogin} />)
+
+    expect(screen.getByText(/すでにアカウントをお持ちですか？/i)).toBeInTheDocument()
+    expect(screen.getByText(/ログイン/i)).toBeInTheDocument()
+  })
+
+  it('renders submit button', () => {
+    render(<SystemAdminSignUpForm onSuccess={() => {}} />)
+
+    const submitButton = screen.getByRole('button', { name: /登録/i })
+    expect(submitButton).toBeInTheDocument()
+    expect(submitButton).not.toBeDisabled()
+  })
+})

--- a/__tests__/features/auth/hooks/useSystemAdminSignIn.test.ts
+++ b/__tests__/features/auth/hooks/useSystemAdminSignIn.test.ts
@@ -1,0 +1,82 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSystemAdminSignIn } from '@/features/auth/hooks/useSystemAdminSignIn'
+import * as systemAdminAuth from '@/features/auth/utils/systemAdminAuth'
+
+jest.mock('@/features/auth/utils/systemAdminAuth')
+
+describe('useSystemAdminSignIn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return initial state', () => {
+    const { result } = renderHook(() => useSystemAdminSignIn())
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBe(null)
+    expect(typeof result.current.execute).toBe('function')
+  })
+
+  it('should handle successful sign in', async () => {
+    const mockSignInSystemAdmin = jest.spyOn(systemAdminAuth, 'signInSystemAdmin')
+    mockSignInSystemAdmin.mockResolvedValue({ success: true })
+
+    const { result } = renderHook(() => useSystemAdminSignIn())
+
+    let response
+    await act(async () => {
+      response = await result.current.execute({
+        emailOrUserName: 'systemadmin@example.com',
+        password: 'password123',
+      })
+    })
+
+    expect(response).toEqual({ success: true })
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBe(null)
+  })
+
+  it('should handle failed sign in', async () => {
+    const mockSignInSystemAdmin = jest.spyOn(systemAdminAuth, 'signInSystemAdmin')
+    mockSignInSystemAdmin.mockResolvedValue({
+      success: false,
+      error: 'メールアドレスまたはパスワードが正しくありません',
+    })
+
+    const { result } = renderHook(() => useSystemAdminSignIn())
+
+    let response
+    await act(async () => {
+      response = await result.current.execute({
+        emailOrUserName: 'systemadmin@example.com',
+        password: 'wrongpassword',
+      })
+    })
+
+    expect(response).toEqual({
+      success: false,
+      error: 'メールアドレスまたはパスワードが正しくありません',
+    })
+    expect(result.current.error).toBe('メールアドレスまたはパスワードが正しくありません')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('should handle exceptions', async () => {
+    const mockSignInSystemAdmin = jest.spyOn(systemAdminAuth, 'signInSystemAdmin')
+    mockSignInSystemAdmin.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useSystemAdminSignIn())
+
+    let response
+    await act(async () => {
+      response = await result.current.execute({
+        emailOrUserName: 'systemadmin@example.com',
+        password: 'password123',
+      })
+    })
+
+    expect(response?.success).toBe(false)
+    expect(result.current.error).toBe('Network error')
+    expect(result.current.isLoading).toBe(false)
+  })
+})

--- a/__tests__/features/auth/hooks/useSystemAdminSignUp.test.ts
+++ b/__tests__/features/auth/hooks/useSystemAdminSignUp.test.ts
@@ -1,0 +1,85 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSystemAdminSignUp } from '@/features/auth/hooks/useSystemAdminSignUp'
+import * as systemAdminAuth from '@/features/auth/utils/systemAdminAuth'
+
+jest.mock('@/features/auth/utils/systemAdminAuth')
+
+describe('useSystemAdminSignUp', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return initial state', () => {
+    const { result } = renderHook(() => useSystemAdminSignUp())
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBe(null)
+    expect(typeof result.current.execute).toBe('function')
+  })
+
+  it('should handle successful sign up', async () => {
+    const mockSignUpSystemAdmin = jest.spyOn(systemAdminAuth, 'signUpSystemAdmin')
+    mockSignUpSystemAdmin.mockResolvedValue({ success: true })
+
+    const { result } = renderHook(() => useSystemAdminSignUp())
+
+    let response
+    await act(async () => {
+      response = await result.current.execute({
+        userName: 'testsystemadmin',
+        email: 'systemadmin@example.com',
+        password: 'password123',
+      })
+    })
+
+    expect(response).toEqual({ success: true })
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBe(null)
+  })
+
+  it('should handle failed sign up', async () => {
+    const mockSignUpSystemAdmin = jest.spyOn(systemAdminAuth, 'signUpSystemAdmin')
+    mockSignUpSystemAdmin.mockResolvedValue({
+      success: false,
+      error: 'メールアドレスは既に登録されています',
+    })
+
+    const { result } = renderHook(() => useSystemAdminSignUp())
+
+    let response
+    await act(async () => {
+      response = await result.current.execute({
+        userName: 'testsystemadmin',
+        email: 'systemadmin@example.com',
+        password: 'password123',
+      })
+    })
+
+    expect(response).toEqual({
+      success: false,
+      error: 'メールアドレスは既に登録されています',
+    })
+    expect(result.current.error).toBe('メールアドレスは既に登録されています')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('should handle exceptions', async () => {
+    const mockSignUpSystemAdmin = jest.spyOn(systemAdminAuth, 'signUpSystemAdmin')
+    mockSignUpSystemAdmin.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useSystemAdminSignUp())
+
+    let response
+    await act(async () => {
+      response = await result.current.execute({
+        userName: 'testsystemadmin',
+        email: 'systemadmin@example.com',
+        password: 'password123',
+      })
+    })
+
+    expect(response?.success).toBe(false)
+    expect(result.current.error).toBe('Network error')
+    expect(result.current.isLoading).toBe(false)
+  })
+})

--- a/__tests__/features/auth/systemAdminAuth.test.ts
+++ b/__tests__/features/auth/systemAdminAuth.test.ts
@@ -1,0 +1,145 @@
+import { signUpSystemAdmin, signInSystemAdmin } from '@/features/auth/utils/systemAdminAuth'
+import { createClient } from '@/lib/supabase/client'
+
+// Mock Supabase client
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(),
+}))
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>
+
+describe('System Admin Auth Utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('signUpSystemAdmin', () => {
+    it('should return success when system admin sign up is successful', async () => {
+      const mockSignUp = jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-system-admin-id' } },
+        error: null,
+      })
+      const mockInsert = jest.fn().mockResolvedValue({ error: null })
+      const mockFrom = jest.fn().mockReturnValue({ insert: mockInsert })
+
+      mockCreateClient.mockReturnValue({
+        auth: { signUp: mockSignUp },
+        from: mockFrom,
+      } as any)
+
+      const mockData = {
+        userName: 'testsystemadmin',
+        email: 'systemadmin@example.com',
+        password: 'password123',
+      }
+
+      const result = await signUpSystemAdmin(mockData)
+      expect(result.success).toBe(true)
+
+      // Verify that the user was created with role 'system_admin'
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: 'system_admin',
+          user_name: 'testsystemadmin',
+          email: 'systemadmin@example.com',
+        })
+      )
+    })
+
+    it('should handle validation errors', async () => {
+      const mockData = {
+        userName: 'ab', // too short
+        email: 'systemadmin@example.com',
+        password: 'password123',
+      }
+
+      const result = await signUpSystemAdmin(mockData)
+      expect(result.success).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should handle duplicate email errors', async () => {
+      const mockSignUp = jest.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'User already registered' },
+      })
+
+      mockCreateClient.mockReturnValue({
+        auth: { signUp: mockSignUp },
+      } as any)
+
+      const mockData = {
+        userName: 'testsystemadmin',
+        email: 'systemadmin@example.com',
+        password: 'password123',
+      }
+
+      const result = await signUpSystemAdmin(mockData)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('既に登録されています')
+    })
+  })
+
+  describe('signInSystemAdmin', () => {
+    it('should return success when system admin sign in is successful', async () => {
+      const mockSignInWithPassword = jest.fn().mockResolvedValue({
+        data: { user: { id: 'test-system-admin-id' } },
+        error: null,
+      })
+
+      mockCreateClient.mockReturnValue({
+        auth: { signInWithPassword: mockSignInWithPassword },
+      } as any)
+
+      const mockData = {
+        emailOrUserName: 'systemadmin@example.com',
+        password: 'password123',
+      }
+
+      const result = await signInSystemAdmin(mockData)
+      expect(result.success).toBe(true)
+    })
+
+    it('should handle validation errors', async () => {
+      const mockData = {
+        emailOrUserName: '', // empty
+        password: 'password123',
+      }
+
+      const result = await signInSystemAdmin(mockData)
+      expect(result.success).toBe(false)
+      expect(result.error).toBeDefined()
+    })
+
+    it('should handle incorrect credentials', async () => {
+      const mockSignInWithPassword = jest.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'Invalid credentials' },
+      })
+
+      mockCreateClient.mockReturnValue({
+        auth: { signInWithPassword: mockSignInWithPassword },
+      } as any)
+
+      const mockData = {
+        emailOrUserName: 'systemadmin@example.com',
+        password: 'wrongpassword',
+      }
+
+      const result = await signInSystemAdmin(mockData)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('正しくありません')
+    })
+
+    it('should only support email login (not username)', async () => {
+      const mockData = {
+        emailOrUserName: 'testsystemadmin', // username without @
+        password: 'password123',
+      }
+
+      const result = await signInSystemAdmin(mockData)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('メールアドレスでのログインのみサポート')
+    })
+  })
+})

--- a/app/system-admin/login/page.tsx
+++ b/app/system-admin/login/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { SystemAdminLoginForm } from '@/features/auth/components/SystemAdminLoginForm'
+
+export default function SystemAdminLoginPage() {
+  const router = useRouter()
+
+  const handleSuccess = () => {
+    // ログイン成功後はダッシュボードへリダイレクト（将来実装予定）
+    router.push('/dashboard')
+  }
+
+  const handleSwitchToSignUp = () => {
+    router.push('/system-admin/signup')
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white shadow-md rounded-lg p-8">
+          <div className="mb-8 text-center">
+            <h1 className="text-2xl font-bold text-gray-900">
+              ログイン
+            </h1>
+            <p className="mt-2 text-sm text-gray-600">
+              システム管理者向け予約システム
+            </p>
+          </div>
+
+          <SystemAdminLoginForm
+            onSuccess={handleSuccess}
+            onSwitchToSignUp={handleSwitchToSignUp}
+          />
+        </div>
+
+        <p className="mt-8 text-center text-xs text-gray-500">
+          © 2025 店舗予約システム. All rights reserved.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/system-admin/signup/page.tsx
+++ b/app/system-admin/signup/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { SystemAdminSignUpForm } from '@/features/auth/components/SystemAdminSignUpForm'
+
+export default function SystemAdminSignUpPage() {
+  const router = useRouter()
+
+  const handleSuccess = () => {
+    // ログイン/登録成功後はダッシュボードへリダイレクト（将来実装予定）
+    router.push('/dashboard')
+  }
+
+  const handleSwitchToLogin = () => {
+    router.push('/system-admin/login')
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white shadow-md rounded-lg p-8">
+          <div className="mb-8 text-center">
+            <h1 className="text-2xl font-bold text-gray-900">
+              アカウント登録
+            </h1>
+            <p className="mt-2 text-sm text-gray-600">
+              システム管理者向け予約システム
+            </p>
+          </div>
+
+          <SystemAdminSignUpForm
+            onSuccess={handleSuccess}
+            onSwitchToLogin={handleSwitchToLogin}
+          />
+        </div>
+
+        <p className="mt-8 text-center text-xs text-gray-500">
+          © 2025 店舗予約システム. All rights reserved.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/features/auth/components/SystemAdminLoginForm.tsx
+++ b/features/auth/components/SystemAdminLoginForm.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { signInSchema, type SignInInput } from '../utils/validation'
+import { useSystemAdminSignIn } from '../hooks/useSystemAdminSignIn'
+
+interface SystemAdminLoginFormProps {
+  onSuccess: () => void
+  onSwitchToSignUp?: () => void
+}
+
+export function SystemAdminLoginForm({ onSuccess, onSwitchToSignUp }: SystemAdminLoginFormProps) {
+  const { execute, isLoading, error: submitError } = useSystemAdminSignIn()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignInInput>({
+    resolver: zodResolver(signInSchema),
+  })
+
+  const onSubmit = async (data: SignInInput) => {
+    const result = await execute(data)
+
+    if (result.success) {
+      onSuccess()
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="emailOrUserName">ユーザー名またはメールアドレス</Label>
+        <Input
+          id="emailOrUserName"
+          type="text"
+          placeholder="ユーザー名またはメールアドレス"
+          {...register('emailOrUserName')}
+          aria-invalid={errors.emailOrUserName ? 'true' : 'false'}
+          aria-describedby={errors.emailOrUserName ? 'emailOrUserName-error' : undefined}
+        />
+        {errors.emailOrUserName && (
+          <p id="emailOrUserName-error" className="text-sm text-destructive" role="alert">
+            {errors.emailOrUserName.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="password">パスワード</Label>
+        <Input
+          id="password"
+          type="password"
+          placeholder="パスワードを入力"
+          {...register('password')}
+          aria-invalid={errors.password ? 'true' : 'false'}
+          aria-describedby={errors.password ? 'password-error' : undefined}
+        />
+        {errors.password && (
+          <p id="password-error" className="text-sm text-destructive" role="alert">
+            {errors.password.message}
+          </p>
+        )}
+      </div>
+
+      {submitError && (
+        <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md" role="alert">
+          {submitError}
+        </div>
+      )}
+
+      <Button type="submit" className="w-full" disabled={isLoading}>
+        {isLoading ? 'ログイン中...' : 'ログイン'}
+      </Button>
+
+      {onSwitchToSignUp && (
+        <div className="text-center text-sm">
+          <span className="text-muted-foreground">アカウントをお持ちでない方は </span>
+          <button
+            type="button"
+            onClick={onSwitchToSignUp}
+            className="text-primary hover:underline"
+          >
+            新規登録
+          </button>
+        </div>
+      )}
+    </form>
+  )
+}

--- a/features/auth/components/SystemAdminSignUpForm.tsx
+++ b/features/auth/components/SystemAdminSignUpForm.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { signUpSchema, type SignUpInput } from '../utils/validation'
+import { useSystemAdminSignUp } from '../hooks/useSystemAdminSignUp'
+
+interface SystemAdminSignUpFormProps {
+  onSuccess: () => void
+  onSwitchToLogin?: () => void
+}
+
+export function SystemAdminSignUpForm({ onSuccess, onSwitchToLogin }: SystemAdminSignUpFormProps) {
+  const { execute, isLoading, error: submitError } = useSystemAdminSignUp()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SignUpInput>({
+    resolver: zodResolver(signUpSchema),
+  })
+
+  const onSubmit = async (data: SignUpInput) => {
+    const result = await execute(data)
+
+    if (result.success) {
+      onSuccess()
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="userName">ユーザー名</Label>
+        <Input
+          id="userName"
+          type="text"
+          placeholder="ユーザー名を入力"
+          {...register('userName')}
+          aria-invalid={errors.userName ? 'true' : 'false'}
+          aria-describedby={errors.userName ? 'userName-error' : undefined}
+        />
+        {errors.userName && (
+          <p id="userName-error" className="text-sm text-destructive" role="alert">
+            {errors.userName.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="email">メールアドレス</Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="email@example.com"
+          {...register('email')}
+          aria-invalid={errors.email ? 'true' : 'false'}
+          aria-describedby={errors.email ? 'email-error' : undefined}
+        />
+        {errors.email && (
+          <p id="email-error" className="text-sm text-destructive" role="alert">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="password">パスワード</Label>
+        <Input
+          id="password"
+          type="password"
+          placeholder="パスワードを入力"
+          {...register('password')}
+          aria-invalid={errors.password ? 'true' : 'false'}
+          aria-describedby={errors.password ? 'password-error' : undefined}
+        />
+        {errors.password && (
+          <p id="password-error" className="text-sm text-destructive" role="alert">
+            {errors.password.message}
+          </p>
+        )}
+      </div>
+
+      {submitError && (
+        <div className="p-3 text-sm text-destructive bg-destructive/10 rounded-md" role="alert">
+          {submitError}
+        </div>
+      )}
+
+      <Button type="submit" className="w-full" disabled={isLoading}>
+        {isLoading ? '登録中...' : '登録'}
+      </Button>
+
+      {onSwitchToLogin && (
+        <div className="text-center text-sm">
+          <span className="text-muted-foreground">すでにアカウントをお持ちですか？ </span>
+          <button
+            type="button"
+            onClick={onSwitchToLogin}
+            className="text-primary hover:underline"
+          >
+            ログイン
+          </button>
+        </div>
+      )}
+    </form>
+  )
+}

--- a/features/auth/hooks/useSystemAdminSignIn.ts
+++ b/features/auth/hooks/useSystemAdminSignIn.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { signInSystemAdmin } from '../utils/systemAdminAuth'
+import type { SignInData } from '../types'
+
+export function useSystemAdminSignIn() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const execute = async (data: SignInData) => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const result = await signInSystemAdmin(data)
+
+      if (!result.success) {
+        setError(result.error || 'サインインに失敗しました')
+        return { success: false, error: result.error }
+      }
+
+      return { success: true }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'サインイン中にエラーが発生しました'
+      setError(message)
+      return { success: false, error: message }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return {
+    execute,
+    isLoading,
+    error,
+  }
+}

--- a/features/auth/hooks/useSystemAdminSignUp.ts
+++ b/features/auth/hooks/useSystemAdminSignUp.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { signUpSystemAdmin } from '../utils/systemAdminAuth'
+import type { SignUpData } from '../types'
+
+export function useSystemAdminSignUp() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const execute = async (data: SignUpData) => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const result = await signUpSystemAdmin(data)
+
+      if (!result.success) {
+        setError(result.error || 'サインアップに失敗しました')
+        return { success: false, error: result.error }
+      }
+
+      return { success: true }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'サインアップ中にエラーが発生しました'
+      setError(message)
+      return { success: false, error: message }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return {
+    execute,
+    isLoading,
+    error,
+  }
+}

--- a/features/auth/utils/systemAdminAuth.ts
+++ b/features/auth/utils/systemAdminAuth.ts
@@ -1,0 +1,143 @@
+import { createClient } from '@/lib/supabase/client'
+import { SignUpData, SignInData, AuthResult } from '../types'
+import { signUpSchema, signInSchema } from './validation'
+import { AuthenticationError, ConflictError, ValidationError } from '@/lib/errors'
+
+/**
+ * システム管理者のサインアップ
+ * 1. Supabase Authでユーザー作成
+ * 2. usersテーブルにプロファイル情報を挿入
+ */
+export async function signUpSystemAdmin(data: SignUpData): Promise<AuthResult> {
+  try {
+    // バリデーション
+    const validated = signUpSchema.parse(data)
+
+    const supabase = createClient()
+
+    // 1. Supabase Authでユーザー作成
+    const { data: authData, error: authError } = await supabase.auth.signUp({
+      email: validated.email,
+      password: validated.password,
+    })
+
+    if (authError) {
+      if (authError.message.includes('already registered')) {
+        throw new ConflictError('このメールアドレスは既に登録されています')
+      }
+      throw new AuthenticationError(authError.message)
+    }
+
+    if (!authData.user) {
+      throw new AuthenticationError('ユーザーの作成に失敗しました')
+    }
+
+    // 2. usersテーブルにプロファイル情報を挿入
+    const { error: profileError } = await supabase
+      .from('users')
+      .insert({
+        id: authData.user.id,
+        role: 'system_admin',
+        user_name: validated.userName,
+        email: validated.email,
+        full_name: '', // 初期値は空文字（後で設定画面で入力）
+      })
+
+    if (profileError) {
+      // プロファイル作成失敗時は認証ユーザーも削除すべきだが、
+      // Supabase Authの削除はサーバーサイドが必要なので、エラーログを出力
+      console.error('Profile creation failed:', profileError)
+      throw new AuthenticationError('ユーザープロファイルの作成に失敗しました')
+    }
+
+    return {
+      success: true,
+    }
+  } catch (error: any) {
+    // Zodのバリデーションエラー
+    if (error.name === 'ZodError') {
+      return {
+        success: false,
+        error: error.errors[0]?.message || 'バリデーションエラーが発生しました',
+      }
+    }
+    if (error instanceof ValidationError) {
+      return {
+        success: false,
+        error: error.message,
+      }
+    }
+    if (error instanceof ConflictError || error instanceof AuthenticationError) {
+      return {
+        success: false,
+        error: error.message,
+      }
+    }
+    // 予期しないエラー
+    console.error('Unexpected error during system admin sign up:', error)
+    return {
+      success: false,
+      error: 'サインアップ中にエラーが発生しました',
+    }
+  }
+}
+
+/**
+ * システム管理者のサインイン
+ * メールアドレスでログイン（ユーザー名は今後実装）
+ */
+export async function signInSystemAdmin(data: SignInData): Promise<AuthResult> {
+  try {
+    // バリデーション
+    const validated = signInSchema.parse(data)
+
+    const supabase = createClient()
+
+    // メールアドレス形式かチェック
+    const isEmail = validated.emailOrUserName.includes('@')
+
+    if (!isEmail) {
+      // ユーザー名の場合の処理
+      // 注: 現在の実装ではメールアドレスのみサポート
+      // ユーザー名でのログインは今後のServer Action実装で対応
+      return {
+        success: false,
+        error: '現在メールアドレスでのログインのみサポートしています',
+      }
+    }
+
+    // サインイン
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email: validated.emailOrUserName,
+      password: validated.password,
+    })
+
+    if (signInError) {
+      throw new AuthenticationError('メールアドレスまたはパスワードが正しくありません')
+    }
+
+    return {
+      success: true,
+    }
+  } catch (error: any) {
+    // Zodのバリデーションエラー
+    if (error.name === 'ZodError') {
+      return {
+        success: false,
+        error: error.errors[0]?.message || 'バリデーションエラーが発生しました',
+      }
+    }
+    if (error instanceof ValidationError || error instanceof AuthenticationError) {
+      return {
+        success: false,
+        error: error.message,
+      }
+    }
+    // 予期しないエラー
+    console.error('Unexpected error during system admin sign in:', error)
+    return {
+      success: false,
+      error: 'ログイン中にエラーが発生しました',
+    }
+  }
+}


### PR DESCRIPTION
- システム管理者向けサインアップ/ログイン機能を追加
- ユーザー用認証実装(Issue #13)を流用し、role='system_admin'に設定
- usersテーブルのemailカラムを使用（カラム名と変数名を一致）

## 実装内容
- features/auth/utils/systemAdminAuth.ts: 認証ロジック
- features/auth/hooks/useSystemAdminSignUp.ts: サインアップフック
- features/auth/hooks/useSystemAdminSignIn.ts: サインインフック
- features/auth/components/SystemAdminSignUpForm.tsx: 登録フォーム
- features/auth/components/SystemAdminLoginForm.tsx: ログインフォーム
- app/system-admin/signup/page.tsx: 登録ページ
- app/system-admin/login/page.tsx: ログインページ

## テスト
- ユニットテスト: 22/22 通過
- Next.jsビルド: 成功（16ページ生成）
- TypeScriptコンパイル: エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)